### PR TITLE
Resolving issue 101

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   before_filter :require_login
   before_filter :require_cookie_directive
   before_filter :load_last_stat
-
+  before_filter :set_no_cache
   require 'record_type'
   require 'name_role'
   require 'chapman_code'
@@ -267,6 +267,11 @@ class ApplicationController < ActionController::Base
     session.delete(:current_page)
   end
 
+  def set_no_cache
+    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+  end
 
 
 

--- a/app/controllers/search_queries_controller.rb
+++ b/app/controllers/search_queries_controller.rb
@@ -95,8 +95,8 @@ class SearchQueriesController < ApplicationController
     else
       @page = nil
     end
-    if params[:search_id]
-      old_query = SearchQuery.search_id(params[:search_id]).first
+    if session[:query]
+      old_query = SearchQuery.search_id(session[:query]).first
       if old_query.present?
         @search_query = SearchQuery.new(old_query.attributes)
       else


### PR DESCRIPTION
Opening a pull request to track this work.

I've tested this code, and it has the effect of changing the behavior of a user who presses the browse back button instead of the 'revise search' button.  I'm not sure the behavior is what we desire, however, so wanted to discuss it.

@israelriibeiro's change affects the how the browser caches pages.  The effect on the search form is that, when the user hits the browser back button, all search form values they enter are blank.  This is more consistent than the current scenario (in which some fields are retained but `place` is eliminated), but I'm not sure users will like it.

If we do go with this version, I'd recommend moving the code from `application_controller` to `search_query_controller` so that it only applies to the search form.

Thoughts, @Captainkirkdawson @edickens @dougkdev @PatReynolds ?
