### PR TITLE
Issue 1192

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -171,4 +171,41 @@ module ApplicationHelper
     Rails.application.config.respond_to?(:ucf_support) && Rails.application.config.ucf_support
   end
 
+  def valid_directory?
+    File.directory?(output_directory_path)
+  end
+
+  # Create a new file named as current date and time
+  def new_file(name)
+    raise "Not a Valid Directory" unless valid_directory?
+
+    file_name = "#{Time.now.strftime("%Y%m%d%H%M%S")}_#{name}.txt"
+    "#{output_directory_path}/#{file_name}"
+  end
+
+  # Set an output directory
+  # If there is no ouput directory, then set the default
+  # else check the trailing slash at the end of the directory
+  def output_directory_path
+    if @output_directory.nil?
+      directory = File.join(Rails.root, 'script')
+    else
+      directory = File.join(@output_directory, "")
+    end
+    directory
+  end
+
+  def delete_file_if_exists(name)
+    File.delete(*Dir.glob("#{output_directory_path}/*_#{name}.txt"))
+  end
+
+  def to_boolean(value)
+    case value
+    when true, 'true', 1, '1', 't' then true
+    when false, 'false', nil, '', 0, '0', 'f' then false
+    when nil, "nil" then nil
+    else
+      raise ArgumentError, "invalid value for Boolean(): \"#{value.inspect}\""
+    end
+  end
 end

--- a/app/models/userid_detail.rb
+++ b/app/models/userid_detail.rb
@@ -373,6 +373,11 @@ class UseridDetail
     user.password != registered_password
   end
 
+  def incomplete_registration_list_rake
+    @users = list_all_users
+    filter_users
+  end
+
   private
 
   def filter_users
@@ -389,7 +394,7 @@ class UseridDetail
   end
 
   def list_all_users
-    self.class.only(:_id, :userid, :password, :person_forename, :person_surname, :email_address, :syndicate)
+    self.class.only(:_id, :userid, :password, :person_forename, :person_surname, :email_address, :syndicate, :active)
   end
 
   def get_users(current_syndicate)

--- a/lib/tasks/filter_active_incomplete_registrations.rake
+++ b/lib/tasks/filter_active_incomplete_registrations.rake
@@ -1,19 +1,17 @@
 namespace :freereg do
 
-  desc "Filter out active users from the Incomplete registrations"
-  task :filter_active_incomplete_registrations => [:environment] do
-    require 'userid_detail'
+  desc "Filter out active/inactive users from the Incomplete registrations"
+  task :filter_active_incomplete_registrations, [:syndicate, :active] => [:environment] do |t, args|
 
-    output_directory = File.join(Rails.root, 'script')
     user = UseridDetail.new
-    
+    active_value = ApplicationController.helpers.to_boolean(args[:active])
 
     # Print the time before start the process
     start_time = Time.now
     p "Starting at #{start_time}"
 
-    p user.incomplete_registration_list_rake.first   
-
+    # Outputs active/inactive incomplete registration userids to text file
+    user.incomplete_registration_user_lists(args[:syndicate], active_value)
 
     p "Process finished"
     running_time = Time.now - start_time

--- a/lib/tasks/filter_active_incomplete_registrations.rake
+++ b/lib/tasks/filter_active_incomplete_registrations.rake
@@ -1,0 +1,22 @@
+namespace :freereg do
+
+  desc "Filter out active users from the Incomplete registrations"
+  task :filter_active_incomplete_registrations => [:environment] do
+    require 'userid_detail'
+
+    output_directory = File.join(Rails.root, 'script')
+    user = UseridDetail.new
+    
+
+    # Print the time before start the process
+    start_time = Time.now
+    p "Starting at #{start_time}"
+
+    p user.incomplete_registration_list_rake.first   
+
+
+    p "Process finished"
+    running_time = Time.now - start_time
+    p "Running time #{running_time} "
+  end
+end


### PR DESCRIPTION
Rake task to filter active incomplete registrations
1. Added methods in application helper that creates a new file in script
folder to output the userids.
2. Added method in the userid detail model to fetch Incomplete
Registration userids based on active field.
3. Created a rake task
The rake task takes two arguments (I) Syndicate (II) Active

3.1) So to fetch both active and inactive userids of Incomplete
Registrations for all syndicates rake command:
**rake freereg:filter_active_incomplete_registrations['all',nil]**

3.2) To fetch active userids of Incomplete Registration for all
syndicates rake command:
**rake freereg:filter_active_incomplete_registrations['all',true]**

3.3) To fetch inactive userids of Incomplete Registrations for all
syndicates rake command:
**rake freereg:filter_active_incomplete_registrations['all',false]**

If we want to fetch active/inactive userids of Incomplete registrations
of any particular synicate for example "General" the rake command:

3.4) To fetch all userids of Incomplete Registrations for 'General'
syndicate
**rake freereg:filter_active_incomplete_registrations['General',nil]**

3.5) To fetch active userids of Incomplete Registrations for 'General'
syndicate
**rake freereg:filter_active_incomplete_registrations['General',true]**

3.6) To fetch inactive userids of Incomplete Registrations for 'General'
syndicate
**rake freereg:filter_active_incomplete_registrations['General',false]**

The syndicate argument should be given in single quotes(as String). Eg
'Anywhere - Transcribe for any county'