### PR TITLE
Added a test to do a a simple FreeREG search; modified dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,5 @@ gem 'uglifier'#, '>= 1.0.3'
 gem 'jquery-rails'
 gem 'refinerycms-county_pages', :path => 'vendor/extensions'
 gem 'rubocop', '~> 0.62.0', require: false
+gem 'capybara'
+gem 'capybara-webkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,17 @@ GEM
     bson (4.3.0)
     builder (3.2.3)
     byebug (10.0.1)
+    capybara (3.13.2)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
+    capybara-webkit (1.15.1)
+      capybara (>= 2.3, < 4.0)
+      json
     carrierwave (1.3.1)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
@@ -469,6 +480,7 @@ GEM
       refinerycms-dragonfly (~> 1.0)
     refinerycms-wymeditor (2.0.0)
       refinerycms-core (>= 4.0.0.dev, < 5.0)
+    regexp_parser (1.3.0)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.0)
@@ -571,6 +583,8 @@ GEM
     websocket-extensions (0.1.3)
     will_paginate (3.1.6)
     xml-simple (1.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zilch-authorisation (0.0.1)
     zip-zip (0.3)
       rubyzip (>= 1.0.0)
@@ -583,6 +597,8 @@ DEPENDENCIES
   airbrake
   bcrypt
   bourbon
+  capybara
+  capybara-webkit
   carrierwave-mongoid
   coffee-rails
   devise

--- a/app/models/church.rb
+++ b/app/models/church.rb
@@ -22,7 +22,7 @@ class Church
   embeds_many :alternatechurchnames
   accepts_nested_attributes_for :alternatechurchnames, allow_destroy: true,  reject_if: :all_blank
 
-  belongs_to :place, index: true
+  belongs_to :place, index: true, optional: true
   index({ place_id: 1, church_name: 1 })
 
   ############################################################# class methods

--- a/app/views/search_queries/_form.html.erb
+++ b/app/views/search_queries/_form.html.erb
@@ -71,7 +71,7 @@
         </li>
 
         <li class="grid__item three-eighths lap-three-quarters palm-one-whole" id="search_query_chapman_codes_input">
-          <input name="search_query[chapman_codes][]" type="hidden" value="">
+          <input  id="search_query_chapman_codes_hidden" name="search_query[chapman_codes][]" type="hidden" value="">
           <label class="ttip label" for="search_query_chapman_codes" tabindex="0">
             County
             <%= image_tag 'info.png', alt: 'Info', height: '16' %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,6 +20,7 @@ MyopicVicar::Application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
+  config.log_level = :debug
   # Configure static asset server for tests with Cache-Control for performance
 
   config.static_cache_control = "public, max-age=3600"
@@ -84,5 +85,5 @@ MyopicVicar::Application.configure do
   config.assets.debug = false
   config.assets.digest = false
   config.dragonfly_secret_code = MyopicVicar::MongoConfig['dragonfly_secret_code']
-
+  config.citation = MyopicVicar::MongoConfig['citation']
 end

--- a/spec/features/smoke_spec.rb
+++ b/spec/features/smoke_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe "test basic functionality" do
+
+
+  it "checks the search page loads" do
+    visit root_path
+    
+    p 'foo'
+  end
+  
+  it "runs a FreeREG search" do
+    # set to FreeREG
+    # process a single csv file
+    visit root_path
+    
+    # verify this is the search form
+    # verify this is FreeREG
+
+    page.fill_in 'last_name', :with => 'first'
+    page.fill_in 'first_name', :with => 'first'
+  #  page.fill_in 'chapman_code', :with => 'KEN'
+    select 'KEN', :from => 'search_query_chapman_codes'
+ #   page.fill_in "search_query_chapman_codes_hidden", :with => 'KEN'
+    page.find('#search_query_chapman_codes').set('KEN') #no ID on these fields so we have to use a selector
+    click_button 'Search'
+    expect(page).to have_content("05 Nov 1653")
+    click_link 'Row 1'
+    expect(page).to have_content("Person forename")
+    expect(page).to have_content("05 Nov 1653")
+    
+  
+  
+    
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,11 @@ RSpec.configure do |config|
   # rspec-rails.
 
   config.infer_base_class_for_anonymous_controllers = false
+  
+  config.infer_spec_type_from_file_location!
+
+  config.include Capybara::DSL
+
 end
 
 def clean_freereg1_csv_file_document(file)


### PR DESCRIPTION
This PR adds `capybara` and `capybara-webkit`, which allow us to write client-side tests that will run the full stack of the application.  This seems like a useful strategy for adding tests to legacy codebases.