### PR TITLE
Prevent record exposure to search engines

### DIFF
--- a/app/views/search_queries/_desktop_freecen.html.erb
+++ b/app/views/search_queries/_desktop_freecen.html.erb
@@ -52,7 +52,7 @@
           <tr id="<%=search_record.id%>">
           <% unless print_friendly %>
             <td>
-              <%= link_to "Detail", friendly_search_record_path(search_record.id, search_record.friendly_url), :title => "Row #{n}, details for #{search_record.transcript_names.first['first_name']} #{search_record.transcript_names.first['last_name']}", :class => "btn weight--light btn--small" %><br />
+              <%= link_to "Detail", friendly_search_record_path(search_record.id, search_record.friendly_url), :rel => "nofollow", :title => "Row #{n}, details for #{search_record.transcript_names.first['first_name']} #{search_record.transcript_names.first['last_name']}", :class => "btn weight--light btn--small" %><br />
           <i><%= viewed(@search_query,search_record) %></i>
         </td>
       <% end %>

--- a/app/views/search_queries/_desktop_freereg.html.erb
+++ b/app/views/search_queries/_desktop_freereg.html.erb
@@ -73,7 +73,7 @@
 </td>
 <% unless print_friendly %>
   <td>
-    <%= link_to("Row #{n}", friendly_search_record_path(search_record.id, search_record.friendly_url),title: "As available for this record")%>
+    <%= link_to("Row #{n}", friendly_search_record_path(search_record.id, search_record.friendly_url),title: "As available for this record",rel:"nofollow")%>
     <i><%= viewed(@search_query,search_record) %></i>
   </td>
 <% end %>


### PR DESCRIPTION
This adds a `rel="nofollow"` link to our search result landing pages that will prevent our actual records from being crawled by search engines.