### PR TITLE
Added Note about 'stop words'

### DIFF
--- a/app/views/freecen2_places/search_names.html.erb
+++ b/app/views/freecen2_places/search_names.html.erb
@@ -7,7 +7,7 @@
 <%= render 'flash_notice' %>
 <div class="island  island--light">
   <%= simple_form_for @freecen2_place, :html => { :class => "grid"}  do |f| %>
-    <%= f.input :place_name, :label => "Search for Place name(s). Previous search name preloaded",:hint => "Names entered are case insensitive and should be the stem of a name e.g. ann will locate ann anns ann's anns'. Results will include both or any of the names entered and will be independent of their order." ,:input_html => {:class => "simple_form_bgcolour", :size => 40 }%>
+    <%= f.input :place_name, :label => "Search for Place name(s). Previous search name preloaded.",:hint => "Names entered are case insensitive and should be the stem of a name e.g. ann will locate ann anns ann's anns'. Results will include both or any of the names entered and will be independent of their order." ,:input_html => {:class => "simple_form_bgcolour", :size => 40 }%>
     <fieldset class="input" style="text-align: center">
       <legend><b> Advanced Search options - </b><i>if required select one</i></legend>
       <small> Note: Only alphabetic characters are permitted in advanced searches and a minimum of 3 characters is required for partial name searches.</small>
@@ -29,5 +29,8 @@
     <%= f.input :county, selected: @county, :label => "County to be searched. Leave empty to search all Counties. Click in box for county options. Previous selection preloaded. ",:include_blank => true, :collection => @counties,:hint =>'', :input_html => {:class => " simple_form_bgcolour simple_form_position overide_selection_field_width"}   %>
     <%= f.hidden_field :disabled, :value=> false %>
     <%= f.button :submit, 'Search Place Names',:button_html => {:class => "btn" }  %>
+    <p class=" text--center"><br>
+      <small><em> [Note: The regular Place Name Search is a text search that ignores ‘stop words’. These are common words that have little actual meaning. A list of these words can be found <%= link_to 'HERE', "https://github.com/mongodb/mongo/blob/0e3b3ca8480ddddf5d0105d11a94bd4698335312/src/mongo/db/fts/stop_words_english.txt", target: :_blank %> (opens in new tab).<br>
+          If your search returns no results and you think it might be because it contains a ‘stop word’, please try an Advanced Search, as this does not ignore 'stop words'.]</em></small></p>
   <% end %>
 </div>


### PR DESCRIPTION
Added Note about 'stop words' to bottom of the Search Place Names page. It includes a link to the 'Github' list of MongoDB english stop words.