### PR TITLE
Update search_queries_helper.rb

### DIFF
--- a/app/helpers/search_queries_helper.rb
+++ b/app/helpers/search_queries_helper.rb
@@ -47,15 +47,6 @@ module SearchQueriesHelper
 
   def format_freecen_birth_year(search_date, record_type)
     search_year = search_date.gsub(/\D.*/,'')
-    if search_year == record_type
-      search_year
-    else
-      if record_type == RecordType::CENSUS_1841 && search_year > "1826"
-        "#{search_year.to_i - 3}"
-      else
-        "#{search_year.to_i - 1}"
-      end
-    end
   end
 
   def format_start_date(year)


### PR DESCRIPTION
Removed unnecessary (and erroneous) adjustment of results display search year for 1841 data.
Note: format_freecen_birth_year method retained as it might be useful for the resolution of the age=999 correction work at a future date.