### PR TITLE
Update freecen_csv_entry.rb

### DIFF
--- a/app/models/freecen_csv_entry.rb
+++ b/app/models/freecen_csv_entry.rb
@@ -2444,18 +2444,10 @@ class FreecenCsvEntry
 
   def validate_on_line_edit_of_fields(fields)
     success, message = FreecenValidations.text?(fields[:surname])
-    if success && fields[:surname].present? && fields[:surname].strip == '-'
-      errors.add(:surname, "has single - Hyphen in Surname") unless fields[:record_valid] == 'true'
-    elsif !success
-      errors.add(:surname, "Invalid; #{message}")
-    end
+    errors.add(:surname, "Invalid; #{message}") unless success || fields[:record_valid] == 'true'
 
     success, message = FreecenValidations.text?(fields[:forenames])
-    if success && fields[:forenames].present? && fields[:forenames].strip == '-'
-      errors.add(:forenames, "has single - Hyphen in Forename") unless fields[:record_valid] == 'true'
-    elsif !success
-      errors.add(:forenames, "Invalid; #{message}")
-    end
+    errors.add(:forenames, "Invalid; #{message}") unless success || fields[:record_valid] == 'true'
 
     success, message = FreecenValidations.name_question?(fields[:name_flag])
     errors.add(:name_flag, "Invalid; #{message}") unless success || fields[:record_valid] == 'true'


### PR DESCRIPTION
Removed additional checking for hyphen in Surname or Forenames in Online Edit Entry processing, as agreed with Geoff J. Validators will have information on how to handle in the Instruction Manual.

@Vino-S please deploy to Test3 and let me know so that I can ask Geoff to test.