### PR TITLE
Update freecen_validations.rb

### DIFF
--- a/lib/freecen_validations.rb
+++ b/lib/freecen_validations.rb
@@ -487,6 +487,8 @@ module FreecenValidations
 
         return [false, 'unusual use of Scholar'] if age.slice(-1).downcase == 'y' && (age[0...-1].to_i < 2 || age[0...-1].to_i > 17) && field.downcase =~ /(scholar)/
 
+        return [false, 'unusual use of Scholar'] if %w[m w d].include?(age.slice(-1).downcase) && field.downcase =~ /(scholar)/
+
       end
 
       return [false, '?'] if field[-1] == '?'


### PR DESCRIPTION
Updated so that if age includes w, m or d (weeks, months, or days) and occupation is Scholar - warning is raised (as for age < 2 or >17) as this would indicate that the individual was < 1.
@Vino-S please deploy to **Test 3** and let me know when that has happened.