### PR TITLE
Verify elements are non-null before adding event listener

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -203,12 +203,12 @@
         classie.toggle(elm, 'navbar_toggle--active');      }
       if (el && el.addEventListener) {
         el.addEventListener('click', switchOffCanvas, false);
-      } else if (el.attachEvent) {
+      } else if (el && el.attachEvent) {
           el.attachEvent('onclick', switchOffCanvas);
       }
       if (cancel && cancel.addEventListener) {
         cancel.addEventListener('click', switchOffCanvas, false);
-      } else if (cancel.attachEvent) {
+      } else if (cancel && cancel.attachEvent) {
           cancel.attachEvent('onclick', switchOffCanvas);
       }
 
@@ -219,9 +219,9 @@
         classie.toggle(document.body, 'offcanvas--active');
         classie.toggle(el, 'site__header__menu-btn--active');
       }
-      if (el.addEventListener) {
+      if (el && el.addEventListener) {
         el.addEventListener('click', switchOffCanvas, false);
-      } else if (el.attachEvent) {
+      } else if (el && el.attachEvent) {
           el.attachEvent('onclick', switchOffCanvas);
       }
     </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -201,12 +201,12 @@
       var switchOffCanvas = function() {
         classie.toggle(document.body, 'offcanvas--active');
         classie.toggle(elm, 'navbar_toggle--active');      }
-      if (el.addEventListener) {
+      if (el && el.addEventListener) {
         el.addEventListener('click', switchOffCanvas, false);
       } else if (el.attachEvent) {
           el.attachEvent('onclick', switchOffCanvas);
       }
-      if (cancel.addEventListener) {
+      if (cancel && cancel.addEventListener) {
         cancel.addEventListener('click', switchOffCanvas, false);
       } else if (cancel.attachEvent) {
           cancel.attachEvent('onclick', switchOffCanvas);


### PR DESCRIPTION
When loading www.freecen.org.uk, I see a few console errors.
Two of these are `Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')`.

This change checks the elements having click listeners attached are truthy before reading their `addEventListener` (or `attachEvent`) attributes. It also future-proofs the subsequent check for element `#trigger-offcanvas-old`.