### PR TITLE
Update freecen_csv_entries_helper.rb

### DIFF
--- a/app/helpers/freecen_csv_entries_helper.rb
+++ b/app/helpers/freecen_csv_entries_helper.rb
@@ -46,7 +46,7 @@ module FreecenCsvEntriesHelper
   end
 
   def propagate_alternate
-    if session[:propagate_alternate].present? && session[:propagate_alternate] == @freecen_csv_entry.id
+    if session[:propagate_alternate].present? && session[:propagate_alternate] == @freecen_csv_entry.id && @year != '1841'
       link_to 'Propagate Alternate Fields', propagate_alternate_freecen_csv_entry_path(@freecen_csv_entry), method: :get, class: "btn btn--small",
         title: 'Propagates the alternate fields to entries with the same verbatim POB fields as this entry',
         data: { confirm: 'Are you sure you want to propagate this entry' }


### PR DESCRIPTION
Updated so that button to propagate the alternate fields to entries with the same verbatim POB fields is not displayed for 1841 census