### PR TITLE
Bug Fixes related to Advanced Search options and Clear County button

### DIFF
--- a/app/controllers/freecen2_places_controller.rb
+++ b/app/controllers/freecen2_places_controller.rb
@@ -289,6 +289,7 @@ class Freecen2PlacesController < ApplicationController
     @counties = @counties.delete_if { |county| county == 'Unknown' }
     get_user_info_from_userid
     @place_name = session[:search_names].present? ? session[:search_names][:search] : ''
+    @advanced_search = session[:search_names].present? ? session[:search_names][:advanced_search] : 'not_applicable'
     if session[:search_names].present?
       if session[:search_names][:clear_county]
         @county = ''
@@ -309,9 +310,9 @@ class Freecen2PlacesController < ApplicationController
 
     search_county = session[:search_names][:search_county]
     @advanced_search = session[:search_names][:advanced_search]
-    if @advanced_search.present?
+    if @advanced_search.present? && @advanced_search != 'not_applicable'
       redirect_back(fallback_location: search_names_freecen2_place_path, notice: 'Advanced search must contain alphabetic characters only') && return unless search_place.match(/^[A-Za-z ]+$/)
-      if @advanced_search != 'soundex' && @advanced_search != 'not_applicable'
+      if @advanced_search != 'soundex'
         redirect_back(fallback_location: search_names_freecen2_place_path, notice: 'Partial searches must contain at least 3 characters') && return unless Freecen2Place.standard_place(search_place).length >= 3
       end
     end

--- a/app/views/freecen2_places/search_names.html.erb
+++ b/app/views/freecen2_places/search_names.html.erb
@@ -13,19 +13,39 @@
       <small> Note: Only alphabetic characters are permitted in advanced searches and a minimum of 3 characters is required for partial name searches.</small>
       <ol class="grid">
         <li class="grid__item one-fifth lap-one-quarter palm-one-whole" id="soundex_search_input">
-          <%= f.radio_button :advanced_search, 'soundex' %> Soundex
+          <% if @advanced_search == 'soundex' %>
+            <%= f.radio_button :advanced_search, 'soundex', :checked =>true %> Soundex
+          <% else %>
+            <%= f.radio_button :advanced_search, 'soundex' %> Soundex
+          <% end%>
         </li>
         <li class="grid__item one-fifth lap-one-quarter palm-one-whole" id="starts_with_search_input">
-          <%= f.radio_button :advanced_search, 'starts_with' %> Starts with
+          <% if @advanced_search == 'starts_with' %>
+            <%= f.radio_button :advanced_search, 'starts_with', :checked =>true %> Starts with
+          <% else %>
+            <%= f.radio_button :advanced_search, 'starts_with' %> Starts with
+          <% end%>
         </li>
         <li class="grid__item one-fifth lap-one-quarter palm-one-whole" id="contains_search_input">
-          <%= f.radio_button :advanced_search, 'contains' %> Contains
+          <% if @advanced_search == 'contains' %>
+            <%= f.radio_button :advanced_search, 'contains', :checked =>true %> Contains
+          <% else %>
+            <%= f.radio_button :advanced_search, 'contains' %> Contains
+          <% end%>
         </li>
         <li class="grid__item one-fifth lap-one-quarter palm-one-whole" id="ends_with_search_input">
-          <%= f.radio_button :advanced_search, 'ends_with' %> Ends with
+          <% if @advanced_search == 'ends_with' %>
+            <%= f.radio_button :advanced_search, 'ends_with', :checked =>true %> Ends with
+          <% else %>
+            <%= f.radio_button :advanced_search, 'ends_with' %> Ends with
+          <% end%>
         </li>
         <li class="grid__item one-fifth lap-one-quarter palm-one-whole" id="no_advanced_search_input">
-          <%= f.radio_button :advanced_search, 'not_applicable', :checked =>true %> N/A
+          <% if @advanced_search.present? && @advanced_search != 'not_applicable' %>
+            <%= f.radio_button :advanced_search, 'not_applicable' %> N/A
+          <% else %>
+            <%= f.radio_button :advanced_search, 'not_applicable', :checked =>true%> N/A
+          <% end %>
         </li>
       </ol>
     </fieldset>


### PR DESCRIPTION
Resolved bug that affected ability to do searches in inverted commas or Boolean searches. 'Clear County' button now clears the county only.