### PR TITLE
 CSV File Lists to be ordered by case insensitive file name

### DIFF
--- a/app/controllers/freecen_csv_files_controller.rb
+++ b/app/controllers/freecen_csv_files_controller.rb
@@ -37,7 +37,7 @@ class FreecenCsvFilesController < ApplicationController
     user = UseridDetail.find(params[:id])
     @who = user.userid
     @role = session[:role]
-    @freecen_csv_files = FreecenCsvFile.userid(user.userid).all.order_by('file_name ASC', 'userid_lower_case ASC').page(params[:page]).per(FreeregOptionsConstants::FILES_PER_PAGE)  unless user.blank?
+    @freecen_csv_files = FreecenCsvFile.userid(user.userid).all.order_by('file_name_lower_case ASC', 'userid_lower_case ASC').page(params[:page]).per(FreeregOptionsConstants::FILES_PER_PAGE)  unless user.blank?
     render 'index'
   end
 
@@ -122,7 +122,8 @@ class FreecenCsvFilesController < ApplicationController
     get_user_info_from_userid
     @who = @first_name
     @sorted_by = 'Alphabetical by file name'
-    session[:sort] = 'file_name ASC'
+    session[:sort] = 'file_name_lower_case ASC'
+    p "AEV01 #{session[:sort]}"
     session[:sorted_by] = @sorted_by
     @freecen_csv_files = FreecenCsvFile.userid(session[:userid]).order_by(session[:sort]).all.page(params[:page]).per(FreeregOptionsConstants::FILES_PER_PAGE)
     render 'index'
@@ -133,7 +134,7 @@ class FreecenCsvFilesController < ApplicationController
     @who = @first_name
     @sorted_by = 'Ordered by number of errors'
     session[:sorted_by] = @sorted_by
-    session[:sort] = 'error DESC, file_name ASC'
+    session[:sort] = 'error DESC, file_name_lower_case ASC'
     @freecen_csv_files = FreecenCsvFile.userid(session[:userid]).errors.order_by(session[:sort]).all.page(params[:page]).per(FreeregOptionsConstants::FILES_PER_PAGE)
     render 'index'
   end
@@ -162,7 +163,7 @@ class FreecenCsvFilesController < ApplicationController
     get_user_info_from_userid
     @who = @first_name
     @freecen_csv_file = FreecenCsvFile.new
-    @freecen_csv_files = FreecenCsvFile.userid(@user.userid).order_by('file_name ASC').all
+    @freecen_csv_files = FreecenCsvFile.userid(@user.userid).order_by('file_name_lower_case ASC').all
     @files = {}
     @freecen_csv_files.each do |file|
       @files[":#{file.file_name}"] = file._id if file.file_name.present?
@@ -329,10 +330,10 @@ class FreecenCsvFilesController < ApplicationController
     case params[:order]
     when 'alphabetic'
       @sorted_by = '; sorted by file name ascending'
-      session[:sort] = 'file_name ASC'
+      session[:sort] = 'file_name_lower_case ASC'
     when 'userid'
       @sorted_by = '; sorted by userid (and then file name ascending)'
-      session[:sort] = 'userid_lower_case ASC, file_name ASC'
+      session[:sort] = 'userid_lower_case ASC, file_name_lower_case ASC'
     when 'oldest'
       @sorted_by = '; ordered by oldest'
       session[:sort] = 'uploaded_date ASC'

--- a/app/controllers/freecen_csv_files_controller.rb
+++ b/app/controllers/freecen_csv_files_controller.rb
@@ -123,7 +123,6 @@ class FreecenCsvFilesController < ApplicationController
     @who = @first_name
     @sorted_by = 'Alphabetical by file name'
     session[:sort] = 'file_name_lower_case ASC'
-    p "AEV01 #{session[:sort]}"
     session[:sorted_by] = @sorted_by
     @freecen_csv_files = FreecenCsvFile.userid(session[:userid]).order_by(session[:sort]).all.page(params[:page]).per(FreeregOptionsConstants::FILES_PER_PAGE)
     render 'index'

--- a/app/controllers/manage_counties_controller.rb
+++ b/app/controllers/manage_counties_controller.rb
@@ -20,12 +20,13 @@ class ManageCountiesController < ApplicationController
     @who = @user.person_forename
     @sorted_by = '; sorted by descending number of errors and then file name'
     session[:sorted_by] = @sorted_by
-    session[:sort] = 'error DESC, file_name ASC'
     session[:selection] = 'errors'
     case appname_downcase
     when 'freereg'
+      session[:sort] = 'error DESC, file_name ASC'
       redirect_to freereg1_csv_files_path
     when 'freecen'
+      session[:sort] = 'error DESC, file_name_lower_case ASC'
       redirect_to freecen_csv_files_path
     end
   end
@@ -36,12 +37,13 @@ class ManageCountiesController < ApplicationController
     @who = @user.person_forename
     @sorted_by = '; being validated'
     session[:sorted_by] = @sorted_by
-    session[:sort] = 'file_name ASC'
     session[:selection] = 'validation'
     case appname_downcase
     when 'freereg'
+      session[:sort] = 'file_name ASC'
       redirect_to freereg1_csv_files_path
     when 'freecen'
+      session[:sort] = 'file_name_lower_case ASC'
       redirect_to freecen_csv_files_path
     end
   end
@@ -102,12 +104,13 @@ class ManageCountiesController < ApplicationController
     @who = @user.person_forename
     @sorted_by = '; sorted alphabetically by file name'
     session[:sorted_by] = @sorted_by
-    session[:sort] = 'file_name ASC'
     session[:selection] = 'all'
     case appname_downcase
     when 'freereg'
+      session[:sort] = 'file_name ASC'
       redirect_to freereg1_csv_files_path
     when 'freecen'
+      session[:sort] = 'file_name_lower_case ASC'
       redirect_to freecen_csv_files_path
     end
   end
@@ -118,12 +121,13 @@ class ManageCountiesController < ApplicationController
     @who = @user.person_forename
     @sorted_by = '; sorted by userid then alphabetically by file name'
     session[:sorted_by] = @sorted_by
-    session[:sort] = 'userid_lower_case ASC, file_name ASC'
     session[:selection] = 'all'
     case appname_downcase
     when 'freereg'
+      session[:sort] = 'userid_lower_case ASC, file_name ASC'
       redirect_to freereg1_csv_files_path
     when 'freecen'
+      session[:sort] = 'userid_lower_case ASC, file_name_lower_case ASC'
       redirect_to freecen_csv_files_path
     end
   end
@@ -193,12 +197,13 @@ class ManageCountiesController < ApplicationController
     @who = @user.person_forename
     @sorted_by = '; incorporated'
     session[:sorted_by] = @sorted_by
-    session[:sort] = 'file_name ASC'
     session[:selection] = 'incorporated'
     case appname_downcase
     when 'freereg'
+      session[:sort] = 'file_name ASC'
       redirect_to freereg1_csv_files_path
     when 'freecen'
+      session[:sort] = 'file_name_lower_case ASC'
       redirect_to freecen_csv_files_path
     end
   end

--- a/app/models/freecen_csv_file.rb
+++ b/app/models/freecen_csv_file.rb
@@ -43,6 +43,7 @@ class FreecenCsvFile
   field :file_digest, type: String
   field :file_errors, type: Array
   field :file_name, type: String
+  field :file_name_lower_case, type: String
   field :flexible, type: Boolean, default: true
   field :locked_by_coordinator, type: Boolean, default: false
   field :locked_by_transcriber, type: Boolean, default: false
@@ -77,7 +78,7 @@ class FreecenCsvFile
   field :type_of_processing, type: String  # placeholder used by change_userid process
 
 
-  before_save :add_lower_case_userid_to_file, :add_country_to_file
+  before_save :add_lower_case_userid_to_file, :add_country_to_file, :add_lower_case_file_name_to_file
   before_create :set_completes_piece_flag
   #after_save :recalculate_last_amended, :update_number_of_files
 
@@ -522,6 +523,10 @@ class FreecenCsvFile
   def add_lower_case_userid_to_file
     # rspec tested directly
     self[:userid_lower_case] = self[:userid].downcase
+  end
+
+  def add_lower_case_file_name_to_file
+    self[:file_name_lower_case] = self[:file_name].downcase
   end
 
   def is_whole_piece(piece)

--- a/lib/tasks/fill_csv_file_name_lower_case.rake
+++ b/lib/tasks/fill_csv_file_name_lower_case.rake
@@ -1,0 +1,33 @@
+desc "Fill_csv_file_lower_case: Populate Freecen_csv_files file_name_lower_case."
+
+task Fill_csv_file_lower_case: :environment do
+
+  file_for_warning_messages = "#{Rails.root}/log/Fill_csv_file_lower_case.log"
+  FileUtils.mkdir_p(File.dirname(file_for_warning_messages))
+  output_file = File.new(file_for_warning_messages, 'w')
+
+  puts 'Fill_csv_file_lower_case: Started.'
+
+  output_file.puts 'Fill_csv_file_lower_case: Started.'
+
+  start_time = Time.current
+  csv_file_records = 0
+  csv_file_successful_records = 0
+
+  FreecenCsvFile.no_timeout.each do |rec|
+
+    csv_file_records += 1
+
+    if rec.update_attributes(file_name_lower_case: rec.file_name.downcase)
+      csv_file_successful_records += 1
+    end
+
+    output_file.puts "Fill_csv_file_lower_case: #{csv_file_records} records processed so far." if (csv_file_records % 1000).zero?
+
+  end
+
+  output_file.puts "Fill_csv_file_lower_case: Out of #{csv_file_records} total freecen_csv_file records, #{csv_file_successful_records} records updated successfully"
+  output_file.puts "Fill_csv_file_lower_case: Completed in #{Time.current - start_time} seconds."
+
+  puts "Fill_csv_file_lower_case: Completed in #{Time.current - start_time} seconds."
+end


### PR DESCRIPTION
Manage County CSV File Lists to be ordered by case insensitive file name. Includes RAKE file to run as part of deployment:
rake Fill_csv_file_lower_case --trace