### PR TITLE
Tidy up and tried to trap send syndicate message when syndicate = all

### DIFF
--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -606,13 +606,13 @@ module MessagesHelper
     elsif message.nature == 'communication' && message.message_sent? && message.not_a_reply? && message.mine?(@user)
       link_to 'Resend Communication', select_role_message_path(message.id, source: action), :class => 'btn btn--small' , data: { confirm: 'Are you sure you want to send this message'}, method: :get
     elsif message.nature == 'syndicate' && !message.message_sent? && message.not_a_reply? && message.mine?(@user)
-      link_to 'Send Syndicate Message', select_recipients_messages_path(message.id, source: action), :class => 'btn btn--small' , data: { confirm: 'Are you sure you want to send this message'}, method: :get
+      link_to 'Select Syndicate Message Recipients and Send', select_recipients_messages_path(message.id, source: action), :class => 'btn btn--small' , data: { confirm: 'Are you sure you want to select recipients and send this message'}, method: :get
     elsif message.nature == 'syndicate' && message.message_sent? && message.not_a_reply? && message.mine?(@user)
-      link_to 'Resend Syndicate Message', select_recipients_messages_path(message.id, source: action), :class => 'btn btn--small' , data: { confirm: 'Are you sure you want to send this message'}, method: :get
+      link_to 'Select Syndicate Message Recipients and Resend', select_recipients_messages_path(message.id, source: action), :class => 'btn btn--small' , data: { confirm: 'Are you sure you want to select recipients and resend this message'}, method: :get
     elsif message.nature == 'general' && !message.message_sent? && message.not_a_reply? && message.mine?(@user)
-      link_to 'Send Message', select_recipients_messages_path(message.id, source: action), :class => 'btn btn--small' , data: { confirm: 'Are you sure you want to send this message'}, method: :get
+      link_to 'Select Message Recipients and Send', select_recipients_messages_path(message.id, source: action), :class => 'btn btn--small' , data: { confirm: 'Are you sure you want to select recipients and send this message'}, method: :get
     elsif message.nature == 'general' && message.message_sent? && message.not_a_reply? && message.mine?(@user)
-      link_to 'Resend Message', select_recipients_messages_path(message.id, source: action), :class => 'btn btn--small' , data: { confirm: 'Are you sure you want to send this message'}, method: :get
+      link_to 'Select Message Recipients and Resend', select_recipients_messages_path(message.id, source: action), :class => 'btn btn--small' , data: { confirm: 'Are you sure you want to select recipients and resend this message'}, method: :get
     end
   end
   def show_view_replies_link(message, action)

--- a/app/views/messages/select_recipients.html.erb
+++ b/app/views/messages/select_recipients.html.erb
@@ -6,7 +6,7 @@
     <%= f.fields_for :sent_message do |multiple| %>
       <div class= "grid">
         <li  class="grid__item  one-fifth  palm-one-whole push--bottom " id="message_recipients">
-          <label class="ttip" for="sender" tabindex="0"> Sender  <%= image_tag 'png/info.png', alt: 'Info', height: '16' %><span  class="ttip__text">Select who is to receive responses. Your userid has been preselected. A blank will use freereg_contacts.</span></a></label>
+          <label class="ttip" for="sender" tabindex="0"> Sender <%= image_tag 'png/info.png', alt: 'Info', height: '16' %><span  class="ttip__text">Select who is to receive responses. Your userid has been preselected at the top of the list.</span></a></label>
         <select id="sender" name="sender" class="select" size="4">
           <% @senders.each do |sender| %>
             <% if sender == @sent_message.sender %>
@@ -38,7 +38,7 @@
       </select>
     </li>
     <li class="grid__item  one-fifth lap-one-whole palm-one-whole">
-      <label class="ttip" for="active" tabindex="0" > Active Member <%= image_tag 'png/info.png', alt: 'Info', height: '16' %><span  class="ttip__text">Remove check to select inactive members</span></a></label>
+      <label class="ttip" for="active" tabindex="0" > Active Members only? <%= image_tag 'png/info.png', alt: 'Info', height: '16' %><span  class="ttip__text">Remove check to select inactive members</span></a></label>
     <% if @sent_message.active %>
       <input type="checkbox" name="active" value= "true" checked >
     <%else%>


### PR DESCRIPTION
Tidy up:
Check box caption: Active Members -> Active Members Only Sender list - put preselected current user at the top of the list Send/Resend message button: text expanded to indicate that it is for selecting the recipients and sending/resending Trap syndicate message if selected syndicate = 'all' , as could not replicate this problem reported in story 1528