### PR TITLE
Jc/refactor assets pipeline

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,6 +7,9 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
 //
+// Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
+// about supported directives.
+//
 // WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
 // GO AFTER THE REQUIRES BELOW.
 //= require jquery

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,25 +9,25 @@
   <head>
     <script src="/prebid_ads.js" type="text/javascript"></script>
     <script>
-    // Define dataLayer and the gtag function.
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
+      // Define dataLayer and the gtag function.
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
 
-      // Default ad_storage to 'denied'.
-      gtag('consent', 'default', {
-        'ad_storage': 'denied',
-        'analytics_storage': 'denied'
-      });
+        // Default ad_storage to 'denied'.
+        gtag('consent', 'default', {
+          'ad_storage': 'denied',
+          'analytics_storage': 'denied'
+        });
     </script>
     <!-- Google Tag Manager -->
     <script>
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','<%= "#{gtm_key_value}"%>');
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','<%= "#{gtm_key_value}"%>');
     </script>
-      <!-- End Google Tag Manager -->
+    <!-- End Google Tag Manager -->
     <script>
       window.update_analytics = function (preference) {
         if(preference == 'accept') {
@@ -63,12 +63,10 @@
         </div>
       <% end %>
     <% end %>
-
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
     <meta charset="utf-8"/>
     <title><%= title %></title>
     <% if MyopicVicar::Application.config.template_set == 'freereg' %>
-      
       <meta name="keywords" content="genealogy,registers,parish,records,church,transcriptions,indexes,baptism,marriage,burial,death,family,history">
       <meta name="description" content="Search your ancestry with FreeREG. FreeREG provides free online access to transcriptions of birth, marriage and burial records from Church of England and Church of Scotland registers. You can also use FreeREG to discover: non-Conformist records from England, Scotland and Wales, Municipal Cemetary records, Memorial records and documents relating to life events out of country, at sea and in the military.  ">
     <% elsif MyopicVicar::Application.config.template_set == 'freecen' %>
@@ -93,26 +91,19 @@
     <link rel="manifest" href="/site.webmanifest">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
-
     <!-- Windows 8.1 + IE11 and above -->
     <meta name="msapplication-config" content="browserconfig.xml" />
-
     <!--link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:italic,300,400,600&display=swap" rel="stylesheet"-->
-
     <!-- Styles -->
-    <%= stylesheet_link_tag    'application', media: 'all' %>
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Source+Sans+Pro:italic,300,400,600&display=swap",rel: "stylesheet","content-encoding" => "gzip" %>
-    <%= stylesheet_link_tag "styles/scss/palm",rel: "stylesheet","content-encoding" => "gzip" %>
-    <%= stylesheet_link_tag 'styles/css/icons.data.svg.css',rel: "stylesheet" %>
-    <%= stylesheet_link_tag "styles/css/donate_icon",rel: "stylesheet" %>
-    <%= stylesheet_link_tag "styles/css/freereg_content",rel: "stylesheet" %>
-    <%= stylesheet_link_tag "styles/scss/freebmd_content",rel: "stylesheet" if appname.downcase == 'freebmd'%>
-    <%= stylesheet_link_tag "styles/scss/lap_and_up", media:"(min-width:571px)",rel: "stylesheet" %>
-    <%= stylesheet_link_tag "styles/scss/ladda",rel: "stylesheet" %>
-    <%= stylesheet_link_tag 'styles/css/icons.data.svg.css' %>
-    <%= stylesheet_link_tag "styles/scss/palm" %>
-    <%= stylesheet_link_tag "styles/scss/lap_and_up", media:"(min-width:571px)" %>
-    <%= stylesheet_link_tag "styles/scss/ladda" %>
+    <%= stylesheet_link_tag "styles/css/donate_icon", 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag "styles/css/icons.data.svg.css", 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag "styles/css/freereg_content", 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag "styles/scss/freebmd_content", 'data-turbolinks-track': 'reload' if appname.downcase == 'freebmd' %>
+    <%= stylesheet_link_tag "styles/scss/palm", 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag "styles/scss/lap_and_up", media: "(min-width:571px)", 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag "styles/scss/ladda", 'data-turbolinks-track': 'reload' %>
     <!--[if (lt IE 9) & (!IEMobile)]>
       <%#= stylesheet_link_tag "styles/css/lap_and_up.min.css" %>
     <![endif]-->
@@ -120,18 +111,8 @@
       <%#= stylesheet_link_tag "styles/css/ie.min" %>
     <![endif]-->
     <%#= raise Rails.root.inspect%>
-    <%= stylesheet_link_tag "styles/css/donate_icon" %>
-    <%= stylesheet_link_tag "styles/css/freereg_content" %>
     <!-- JavaScripts -->
-    <%= javascript_include_tag "application"%>
-    <%= javascript_include_tag "jquery.min.js"%>
-    <%= javascript_include_tag "jquery.validate.min.js"%>
-    <%= javascript_include_tag "jquery.chained.remote.js"%>
-    <%= javascript_include_tag "cookie_control.js"%>
-    <%= javascript_include_tag "jquery.cookiesDirective.js"%>
-    <%= javascript_include_tag "spin.min.js"%>
-    <%= javascript_include_tag "ladda.min.js"%>
-    <%= javascript_include_tag "freecen_coverage_graph.js" %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag "#{appname.downcase}_advert_control.js" %>
     <% if appname.downcase == 'freecen' && GdprCountries::FOLLOWED_COUNTRIES.include?(user_location) %>
       <%= javascript_include_tag "javascripts/freecen_gdpr.js" %>
@@ -211,7 +192,6 @@
       } else if (cancel.attachEvent) {
           cancel.attachEvent('onclick', switchOffCanvas);
       }
-
     </script>
     <script type="text/javascript">
       var el = document.getElementById("trigger-offcanvas-old");

--- a/config/application.rb
+++ b/config/application.rb
@@ -77,7 +77,6 @@ module MyopicVicar
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
     config.assets.enabled = true
-    config.assets.version = '1.0'
     # Change the path that assets are served from config.assets.prefix = "/assets"
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = 'utf-8'
@@ -127,8 +126,6 @@ module MyopicVicar
 
     # Enable the asset pipeline
     config.assets.enabled = true # commented out because already set above
-    # Version of your assets, change this if you want to expire all your assets
-    # config.assets.version = '1.0' # commented out because already set above
 
     # config.active_record.whitelist_attributes = true Remove as no longer relevant in rails 4.2
     config.api_only = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,16 +40,34 @@ MyopicVicar::Application.configure do
   config.action_dispatch.best_standards_support = :builtin
   config.serve_static_files = true
 
+
+  # Turning Source Maps On, disables concatenation and preprocessing of assets
+  # config.assets.debug = true    # for assets pipeline debugging
+  config.assets.debug = false
+
+  # Enable live sprockets assets pipeline compilation
+  # config.assets.compile = true    # for assets pipeline debugging
+  config.assets.compile = false
+
+  # Turning Digests (fingerprinting) On
+  # config.assets.digest = false    # for assets pipeline debugging
+  config.assets.digest = true
+
+  # Enables additional runtime error checking.
+  # Minimize unexpected behaviour when deploying to `production`
+  # config.assets.raise_runtime_errors = true   # for assets pipeline debugging
+  config.assets.raise_runtime_errors = false
+
+  # Raise an Error When an Asset is Not Found
+  # config.assets.unknown_asset_fallback = false    # default, for assets pipeline debugging
+  config.assets.unknown_asset_fallback = true
+
   # Do not compress assets
   config.assets.compress = false
 
-  # Expands the lines which load the assets
-  config.assets.debug = false
-  config.assets.raise_runtime_errors = false
-  config.assets.compile = false
   # Raise exception on mass assignment protection for Active Record models
   config.assets.check_precompiled_asset = false
-  config.assets.unknown_asset_fallback = true
+
   config.assets.skip_pipelines = true
 
   # Log the query plan for queries taking more than this (works

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,34 +4,14 @@
 
 Rails.application.configure do
   config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
-  config.assets.paths << Rails.root.join('app', 'assets', 'images')
-  config.assets.paths << Rails.root.join('app', 'assets', 'images', 'png')
-  config.assets.paths << Rails.root.join('app', 'assets', 'images', 'svg', 'min')
-  config.assets.paths << Rails.root.join('app', 'assets', 'images', 'svg', 'src')
 
   config.assets.precompile += %w[styles/scss/lap_and_up.scss]
-  config.assets.precompile += %w[styles/scss/ie.scss]
   config.assets.precompile += %w[styles/scss/palm.scss]
   config.assets.precompile += %w[styles/scss/ladda.scss]
-  config.assets.precompile += %w[favicon.ico]
+  config.assets.precompile += %w[styles/css/donate_icon.css]
   config.assets.precompile += %w[styles/css/icons.data.svg.css]
-  config.assets.precompile += %w[styles/css/donate_icon.css]
-  config.assets.precompile += %w[styles/css/icons.data.png.css]
-  config.assets.precompile += %w[styles/css/icons.fallback.css]
   config.assets.precompile += %w[styles/css/freereg_content.css]
-  config.assets.precompile += %w[styles/css/ladda.min.css]
-  config.assets.precompile += %w[jquery.min.js]
-  config.assets.precompile += %w[jquery.chained.remote.js]
-  config.assets.precompile += %w[jquery.cookiesDirective.js]
-  config.assets.precompile += %w[html5shiv.js]
-  config.assets.precompile += %w[spin.min.js]
-  config.assets.precompile += %w[ladda.min.js]
-  config.assets.precompile += %w[ads.js]
-  config.assets.precompile += %w[adsbygoogle.js]
+  
   config.assets.precompile += %w[prebid_ads.js]
-  config.assets.precompile += %w[freecen_coverage_graph.js]
-  config.assets.precompile += %w[styles/css/donate_icon.css]
-  config.assets.precompile += %w[cookie_control.js]
-  config.assets.precompile += %w[advert_control.js]
   config.assets.precompile += %w( javascripts/freecen_gdpr.js )
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,6 +1,19 @@
-# Enable the asset pipeline
+# Be sure to restart your server when you modify this file.
 
-# Version of your assets, change this if you want to expire all your assets
+# Version of your assets, change this if you want to expire all your assets.
+Rails.application.config.assets.version = '1.0'
+
+# Add additional assets to the asset load path.
+# Rails.application.config.assets.paths << Emoji.images_path
+# Add Yarn node_modules folder to the asset load path.
+# Rails.application.config.assets.paths << Rails.root.join('node_modules')
+
+# Precompile additional assets.
+# application.js, application.css, and all non-JS/CSS in the app/assets
+# folder are already added.
+# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+# Enable the asset pipeline
 
 Rails.application.configure do
   config.assets.paths << Rails.root.join('app', 'assets', 'fonts')


### PR DESCRIPTION
- remove redundant/duplicate code
- standardise stylesheet_link_tag and javascript_include_tag command format
- reorganise config.assets setting 
- add additional documentation note
- reorganise setting code to follow Rails 5.x convention