### PR TITLE
Fc_1811_av

### DIFF
--- a/app/views/freecen1_vld_files/index.html.erb
+++ b/app/views/freecen1_vld_files/index.html.erb
@@ -33,32 +33,32 @@
           <td><%= freecen1_vld_file.transcriber_name %></td>
           <% if %w[system_administrator data_manager county_coordinator master_county_coordinator country_coordinator].include?(session[:role])%>
             <td><%= pob_val_status(freecen1_vld_file)  %></td>
-            <%# if pob_val_status(freecen1_vld_file) != 'All POBs are valid'%>
-              <!--td><%#= link_to 'Pre-Validation', auto_validate_pobs_freecen1_vld_file_path(id: freecen1_vld_file.id), method: :get, data: { confirm:  'Are you sure you want to Run Auto POB Validation for '+freecen1_vld_file.file_name+'?'} %></td-->
-            <%# else %>
-              <td><%= 'Pre-Validation N/A' %>
-            <%# end %>
-            <td><%= link_to 'List VLD Entries', entry_csv_download_freecen1_vld_file_path(id: freecen1_vld_file.id), title: 'Download VLD Entries',data: { confirm: 'Are you sure you want to download a list of entries for '+freecen1_vld_file.file_name+'?'}, method: :get %></td>
-            <% if  pob_val_status(freecen1_vld_file) != 'All POBs are valid'  && pob_val_status(freecen1_vld_file) != 'Not Started'%>
-              <td><%= link_to 'Manual Val', manual_validate_pobs_freecen1_vld_file_path(id: freecen1_vld_file.id), method: :get, data: { confirm:  'Are you sure you want to Manually Validate '+freecen1_vld_file.file_name+'?'} %></td>
+            <% if pob_val_status(freecen1_vld_file) != 'All POBs are valid'%>
+              <td><%= link_to 'Pre-Validation', auto_validate_pobs_freecen1_vld_file_path(id: freecen1_vld_file.id), method: :get, data: { confirm:  'Are you sure you want to Run Auto POB Validation for '+freecen1_vld_file.file_name+'?'} %></td>
             <% else %>
-              <td><%= 'Manual Val N/A' %>
-            <% end %>
+              <td><%= 'Pre-Validation N/A' %>
+              <% end %>
+              <td><%= link_to 'List VLD Entries', entry_csv_download_freecen1_vld_file_path(id: freecen1_vld_file.id), title: 'Download VLD Entries',data: { confirm: 'Are you sure you want to download a list of entries for '+freecen1_vld_file.file_name+'?'}, method: :get %></td>
+              <% if  pob_val_status(freecen1_vld_file) != 'All POBs are valid'  && pob_val_status(freecen1_vld_file) != 'Not Started'%>
+                <td><%= link_to 'Manual Val', manual_validate_pobs_freecen1_vld_file_path(id: freecen1_vld_file.id), method: :get, data: { confirm:  'Are you sure you want to Manually Validate '+freecen1_vld_file.file_name+'?'} %></td>
+              <% else %>
+                <td><%= 'Manual Val N/A' %>
+                <% end %>
+              <% end %>
+              <td><%= link_to 'Show', freecen1_vld_file_path(freecen1_vld_file) %></td>
+              <% if %w[system_administrator data_manager executive_director county_coordinator country_coordinator master_county_coordinator].include?(session[:role])%>
+                <% if %w[system_administrator data_manager country_coordinator].include?(session[:role])%>
+                  <td><%= link_to 'Download', download_vld_file_freecen1_vld_file_path(file: freecen1_vld_file.id), title: 'Download VLD file',data: { confirm: 'Are you sure you want to download '+freecen1_vld_file.file_name+'?'}, method: :get %></td>
+                  <td><%= link_to 'Replace', new_freecen1_vld_file_path(replace: freecen1_vld_file.file_name), data: { confirm: 'Are you sure you want to Replace '+freecen1_vld_file.file_name+'?'}, method: :get %></td>
+                <% end%>
+                <td><%= link_to 'Delete', freecen1_vld_file_path(freecen1_vld_file), data: { disable_with:"<i class='fa fa-spinner fa-spin'></i>Deleting", confirm: 'Are you sure you want to delete '+freecen1_vld_file.file_name+'? It may take some time to process, you will receive a message when the file delete has completed.'}, method: :delete %></td>
+                <td><%= link_to 'Edit Transcriber', edit_freecen1_vld_file_path(freecen1_vld_file), method: :get, data: { confirm:  'Are you sure you want to edit Transcriber for '+freecen1_vld_file.file_name+'?'} %></td>
+                <td><%= link_to 'Edit Civil Parishes', edit_civil_parishes_freecen1_vld_file_path(id: freecen1_vld_file.id), method: :get, data: { confirm:  'Are you sure you want to edit Civil Parishes for for '+freecen1_vld_file.file_name+'?'} %></td>
+              <% end %>
+            </tr>
           <% end %>
-          <td><%= link_to 'Show', freecen1_vld_file_path(freecen1_vld_file) %></td>
-          <% if %w[system_administrator data_manager executive_director county_coordinator country_coordinator master_county_coordinator].include?(session[:role])%>
-            <% if %w[system_administrator data_manager country_coordinator].include?(session[:role])%>
-              <td><%= link_to 'Download', download_vld_file_freecen1_vld_file_path(file: freecen1_vld_file.id), title: 'Download VLD file',data: { confirm: 'Are you sure you want to download '+freecen1_vld_file.file_name+'?'}, method: :get %></td>
-              <td><%= link_to 'Replace', new_freecen1_vld_file_path(replace: freecen1_vld_file.file_name), data: { confirm: 'Are you sure you want to Replace '+freecen1_vld_file.file_name+'?'}, method: :get %></td>
-            <% end%>
-            <td><%= link_to 'Delete', freecen1_vld_file_path(freecen1_vld_file), data: { disable_with:"<i class='fa fa-spinner fa-spin'></i>Deleting", confirm: 'Are you sure you want to delete '+freecen1_vld_file.file_name+'? It may take some time to process, you will receive a message when the file delete has completed.'}, method: :delete %></td>
-            <td><%= link_to 'Edit Transcriber', edit_freecen1_vld_file_path(freecen1_vld_file), method: :get, data: { confirm:  'Are you sure you want to edit Transcriber for '+freecen1_vld_file.file_name+'?'} %></td>
-            <td><%= link_to 'Edit Civil Parishes', edit_civil_parishes_freecen1_vld_file_path(id: freecen1_vld_file.id), method: :get, data: { confirm:  'Are you sure you want to edit Civil Parishes for for '+freecen1_vld_file.file_name+'?'} %></td>
-          <% end %>
-        </tr>
-      <% end %>
-    <% end %>
-  </table>
-</div>
-<br>
-<br>
+        <% end %>
+      </table>
+    </div>
+    <br>
+    <br>

--- a/lib/freecen_csv_processor.rb
+++ b/lib/freecen_csv_processor.rb
@@ -846,11 +846,17 @@ class CsvRecords < CsvFile
     end
 
     while line[n].present?
-      if Freecen::FIELD_NAMES_CONVERSION.key?(line[n].downcase)
-        field_specification[n] = Freecen::FIELD_NAMES_CONVERSION[line[n].downcase]
-      else
-        success = false
-        message = message + "ERROR: column header at position #{n} is invalid  #{line[n]}.<br>"
+      unless %w[pob_valid non_pob_valid].include?(line[n].downcase) && @csvfile.validation
+        if Freecen::FIELD_NAMES_CONVERSION.key?(line[n].downcase)
+          field_specification[n] = Freecen::FIELD_NAMES_CONVERSION[line[n].downcase]
+        else
+          success = false
+          if %w[pob_valid non_pob_valid].include?(line[n].downcase)
+            message += "ERROR: header field #{line[n].downcase} should not be included as the file is not being validated.<br>"
+          else
+            message += "ERROR: column header at position #{n} is invalid  #{line[n]}.<br>"
+          end
+        end
       end
       n = n + 1
     end
@@ -860,16 +866,16 @@ class CsvRecords < CsvFile
         next if field == 'language' && (ChapmanCode::CODES['England'].values.member?(@csvfile.chapman_code) || @csvfile.chapman_code == 'IOM')
         next if field_specification.value?(field)
         success = false
-        message = message + "ERROR: the field #{field} is missing from the #{@csvfile.year} spreadsheet.<br>"
+        message += "ERROR: the field #{field} is missing from the #{@csvfile.year} spreadsheet.<br>"
       end
       field_specification.values.each do |value|
-        next if %w[deleted_flag record_valid].include?(value) && @csvfile.validation
+        next if %w[deleted_flag record_valid pob_valid non_pob_valid].include?(value) && @csvfile.validation
         next if @csvfile.census_fields.include?(value)
         success = false
         if  %w[deleted_flag record_valid].include?(value)
-          message = message + "ERROR: header field #{value} should not be included as the file is not being validated.<br>"
+          message += "ERROR: header field #{value} should not be included as the file is not being validated.<br>"
         else
-          message = message + "ERROR: header field #{value} should not be included it is not part in the spreadsheet for #{@csvfile.year}.<br>"
+          message += "ERROR: header field #{value} should not be included it is not part in the spreadsheet for #{@csvfile.year}.<br>"
         end
       end
     end


### PR DESCRIPTION
Correct Pre_validation for CSV file so that POB_VALID and NON_POB_VAlID fields are ignored by the CSV processor unless Validation has commenced for a CSVPoc file. Relates to 'Pre-validation' issue identified by Geoff when an old version of the code was accidentally deployed as part of another branch deployment.
Re-instate Pre-validation option for  VLD files.This was commented out in attempt to resolve Pre-validation issue but I believe it was the CSV Pre-validation that had the issue not VLD Pre-validation.