### PR TITLE
Change the name of the POB propagation collection

### DIFF
--- a/app/controllers/freecen_pob_propagations_controller.rb
+++ b/app/controllers/freecen_pob_propagations_controller.rb
@@ -1,0 +1,54 @@
+# Copyright 2012 Trustees of FreeBMD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+#
+class FreecenPobPropagationsController < ApplicationController
+
+  def destroy
+    @pob_propagation = FreecenPobPropagation.find(params[:id])
+    redirect_back(fallback_location: { action: 'index' }, notice: 'The pob propagation was not found ') && return if @pob_propagation.blank?
+
+    @pob_propagation.delete
+    flash[:notice] = 'The destruction of the pob propagation was successful'
+    redirect_to action: 'index'
+  end
+
+  def index
+    get_user_info_from_userid
+    @chapman_code = session[:chapman_code]
+    @county = session[:county]
+    params[:sorted_by] = 'Most Recent Creation Date' if params[:sorted_by].blank?
+    @sorted_by = params[:sorted_by]
+    case @sorted_by
+    when 'Most Recent Creation Date'
+      @pob_propagations = FreecenPobPropagation.where(match_verbatim_birth_county: @chapman_code).order_by(c_at: -1)
+    when 'Verbatim Birth Place'
+      @pob_propagations = FreecenPobPropagation.where(match_verbatim_birth_county: @chapman_code).order_by(match_verbatim_birth_county: 1)
+    end
+  end
+
+
+  def show
+    @pob_propagation = FreecenPobPropagation.find(params[:id])
+    redirect_back(fallback_location: { action: 'index' }, notice: 'The pob propagation was not found ') && return if @pob_propagation.blank?
+
+    get_user_info_from_userid
+    @chapman_code = session[:chapman_code]
+    @county = session[:county]
+  end
+
+  private
+
+  def freecen_pob_propagation_params
+    params.require(:freecen_pob_propagation).permit!
+  end
+end

--- a/app/models/freecen1_vld_entry.rb
+++ b/app/models/freecen1_vld_entry.rb
@@ -135,14 +135,14 @@ class Freecen1VldEntry
 
   def propagate_collection(propagation_fields, userid)
     propagate_pob, propagate_notes = propagation_flags(propagation_fields)
-    success = Freecen1VldEntryPropagation.create_new_propagation('ALL', 'ALL', verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
+    success = FreecenPobPropagation.create_new_propagation('ALL', 'ALL', verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
     error_message = success ? '' : 'Propagation record for Collection not created as it already exists. Please re-run Auto Validation on this VLD file.'
     [success, error_message]
   end
 
   def propagate_county(propagation_fields, chapman_code, userid)
     propagate_pob, propagate_notes = propagation_flags(propagation_fields)
-    success = Freecen1VldEntryPropagation.create_new_propagation('ALL', chapman_code, verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
+    success = FreecenPobPropagation.create_new_propagation('ALL', chapman_code, verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
     error_message = success ? '' : 'Propagation record for County not created as it already exists. Please re-run Auto Validation on this VLD file.'
     [success, error_message]
   end
@@ -194,7 +194,7 @@ class Freecen1VldEntry
     if vld_file.present?
       census_year = vld_file.full_year
       propagate_pob, propagate_notes = propagation_flags(propagation_fields)
-      success = Freecen1VldEntryPropagation.create_new_propagation(census_year, 'ALL', verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
+      success = FreecenPobPropagation.create_new_propagation(census_year, 'ALL', verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
       error_message = success ? '' : 'Propagation record for Year not created as it already exists. Please re-run Auto Validation on this VLD file.'
     else
       error_message = 'Error creating Propagation record - VLD File not Found'

--- a/app/models/freecen_csv_entry.rb
+++ b/app/models/freecen_csv_entry.rb
@@ -1870,7 +1870,7 @@ class FreecenCsvEntry
     end
     if scope == 'All'
       propagate_pob, propagate_notes = propagation_flags('Alternative')
-      ok = Freecen1VldEntryPropagation.create_new_propagation('ALL', 'ALL', verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
+      ok = FreecenPobPropagation.create_new_propagation('ALL', 'ALL', verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
       message = ok ? '' : 'Propagation successful for File but please note Propagation record for Collection already exists.'
     end
     [@warnings_adjustment, success, message]
@@ -1902,7 +1902,7 @@ class FreecenCsvEntry
     end
     if scope == 'All'
       propagate_pob, propagate_notes = propagation_flags('Notes')
-      ok = Freecen1VldEntryPropagation.create_new_propagation('ALL', 'ALL', verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
+      ok = FreecenPobPropagation.create_new_propagation('ALL', 'ALL', verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
       message = ok ? '' : 'Propagation successful for File but please note Propagation record for Collection already exists.'
     end
     [@warnings_adjustment, success, message]
@@ -1936,7 +1936,7 @@ class FreecenCsvEntry
     end
     if scope == 'All'
       propagate_pob, propagate_notes = propagation_flags('Both')
-      ok = Freecen1VldEntryPropagation.create_new_propagation('ALL', 'ALL', verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
+      ok = FreecenPobPropagation.create_new_propagation('ALL', 'ALL', verbatim_birth_county, verbatim_birth_place, birth_county, birth_place, notes, propagate_pob, propagate_notes, userid)
       message = ok ? '' : 'Propagation successful for File but Propagation record for Whole Collection not created as it already exists.'
     end
     [@warnings_adjustment, success, message]

--- a/app/models/freecen_pob_propagation.rb
+++ b/app/models/freecen_pob_propagation.rb
@@ -1,0 +1,43 @@
+class FreecenPobPropagation
+  include Mongoid::Document
+  include Mongoid::Timestamps::Short
+  field :scope_year, type: String
+  field :scope_county, type: String
+  field :match_verbatim_birth_county, type: String
+  field :match_verbatim_birth_place, type: String
+  field :new_birth_county, type: String
+  field :new_birth_place, type: String
+  field :new_notes, type: String
+  field :propagate_pob, type: Boolean
+  field :propagate_notes, type: Boolean
+  field :created_by, type: String
+
+  ############################################################## class methods
+
+  class << self
+    def create_new_propagation(scope_year, scope_county, match_verbatim_birth_county, match_verbatim_birth_place, new_birth_county, new_birth_place, new_notes, propagate_pob, propagate_notes, userid)
+      existing_prop = FreecenPobPropagation.where(scope_year: scope_year, scope_county: scope_county, match_verbatim_birth_county: match_verbatim_birth_county, match_verbatim_birth_place: match_verbatim_birth_place).first
+      if existing_prop.blank?
+        new_prop = FreecenPobPropagation.new
+        new_prop.scope_year = scope_year
+        new_prop.scope_county = scope_county
+        new_prop.match_verbatim_birth_county = match_verbatim_birth_county
+        new_prop.match_verbatim_birth_place = match_verbatim_birth_place
+        new_prop.new_birth_county = new_birth_county
+        new_prop.new_birth_place = new_birth_place
+        new_prop.new_notes = new_notes
+        new_prop.propagate_pob = propagate_pob
+        new_prop.propagate_notes = propagate_notes
+        new_prop.created_by = userid
+        new_prop.save!
+        success = true
+      else
+        success = false
+      end
+      success
+    end
+  end
+
+  ############################################################### instance methods
+
+end

--- a/app/views/freecen_pob_propagations/index.html.erb
+++ b/app/views/freecen_pob_propagations/index.html.erb
@@ -1,0 +1,36 @@
+<% breadcrumb :freecen_pob_propagations,@chapman_code %>
+<h1 style="text-align: center">Listing of FreeCen POB Propagations for <%= @county%> (<%= @chapman_code%>)</h1>
+<h2 style="text-align: center">ordered by <%=@sorted_by%></h2>
+<div class=" text--center push--bottom">
+  Click button to change the order of display :
+  <% if @sorted_by != 'Most Recent Creation Date' %>
+    <%= link_to 'Most Recent Creation Date', freecen_pob_propagations_path(county: @county, sorted_by: 'Most Recent Creation Date'), method: :get , :class => "btn btn--small", title: 'Reorder the list showing most recently created first' %>
+  <% end %>
+  <% if @sorted_by != 'Verbatim Birth Place' %>
+    <%= link_to 'Verbatim Birth Place', freecen_pob_propagations_path(county: @county, sorted_by: 'Verbatim Birth Place'), method: :get , :class => "btn btn--small", title: 'Reorder the list according to the alphabetical Verbatim Place Name' %>
+  <% end %>
+</div>
+<div class="scrollable ">
+  <table class="table--bordered table--data table--striped ">
+    <% if @pob_propagations.present? %>
+      <tr>
+        <th class='sticky-header '> Verbatim Birth County</th>
+        <th class='sticky-header '> Verbatim Birth Place</th>
+        <th class='sticky-header '> Created By</th>
+        <th class='sticky-header '> Creation Date</th>
+        <th class='sticky-header '> Action</th>
+      </tr>
+      <% @pob_propagations.each do |prop| %>
+        <tr>
+          <td><%= prop.match_verbatim_birth_county %></td>
+          <td><%= prop.match_verbatim_birth_place %></td>
+          <td><%= prop.created_by %></td>
+          <td><%= prop.c_at.strftime("%Y-%m-%d %H:%M:%S") %></td>
+          <td><%= link_to 'Show', freecen_pob_propagation_path(prop) %></td>
+        </tr>
+      <% end %>
+    <% else%>
+      <p class="text--center"> No POB Propagations found</p>
+    <% end%>
+  </table>
+</div>

--- a/app/views/freecen_pob_propagations/show.html.erb
+++ b/app/views/freecen_pob_propagations/show.html.erb
@@ -1,0 +1,84 @@
+<% breadcrumb :freecen_pob_propagation, @chapman_code, @pob_propagation%>
+<h1 style="text-align: center">FreeCen POB Propagation for <%= @county%> (<%= @chapman_code%>)</h1>
+<div style="text-align: center">
+  <%= link_to 'Delete POB Propagation Record', freecen_pob_propagation_path(@pob_propagation), method: :delete, data: { disable_with:"<i class='fa fa-spinner fa-spin'></i>Deleting", confirm: 'Are you sure you want to delete this POB Propagation Record?' } , :class => "btn  btn--small"%>
+</div>
+<div class="grid">
+  <section class="island ">
+    <div class="grid__item ">
+      <table   class="table--bordered table--striped  table--data">
+        <colgroup >
+          <col class=t40>
+          <col class=t60>
+        </colgroup>
+        <tr>
+          <th class="caps">Field</th>
+          <th  class="caps">Value</th>
+        </tr>
+        <tr>
+          <td>Verbatim Birth County:</td>
+          <td class="weight--semibold">
+            <%= @pob_propagation.match_verbatim_birth_county %> </td>
+        </tr>
+        <tr>
+          <td>Verbatim Birth Place:</td>
+          <td class="weight--semibold">
+            <%= @pob_propagation.match_verbatim_birth_place %> </td>
+        </tr>
+        <tr>
+          <td>Scope Year (ALL = All years):</td>
+          <td class="weight--semibold">
+            <%= @pob_propagation.scope_year  %></td>
+        </tr>
+        <tr>
+          <td>Scope County (ALL = All Counties):</td>
+          <td class="weight--semibold">
+            <%= @pob_propagation.scope_county  %></td>
+        </tr>
+        <tr>
+          <td>Propagate POB:</td>
+          <% if @pob_propagation.propagate_pob %>
+            <td class="weight--semibold">Yes</td>
+          <% else %>
+            <td class="weight--semibold">No</td>
+          <% end %>
+        </tr>
+        <tr>
+          <td>Alternate Birth County:</td>
+          <td class="weight--semibold">
+            <%= @pob_propagation.new_birth_county %> </td>
+        </tr>
+        <tr>
+          <td>Alternate Birth Place:</td>
+          <td class="weight--semibold">
+            <%= @pob_propagation.new_birth_place %> </td>
+        </tr>
+        <tr>
+          <td>Propagate Note:</td>
+          <% if @pob_propagation.propagate_notes %>
+            <td class="weight--semibold">Yes</td>
+          <% else %>
+            <td class="weight--semibold">No</td>
+          <% end %>
+        </tr>
+        <tr>
+          <td>Note:</td>
+          <td class="weight--semibold">
+            <%= @pob_propagation.new_notes %> </td>
+        </tr>
+        <tr>
+          <td>Created by:</td>
+          <td class="weight--semibold">
+            <%= @pob_propagation.created_by  %></td>
+        </tr>
+        <tr>
+          <td>Creation Date:</td>
+          <td class="weight--semibold">
+            <%= @pob_propagation.c_at.strftime("%Y-%m-%d %H:%M:%S") %></td>
+        </tr>
+      </p>
+    </table>
+  </div>
+</section>
+</div>
+<br>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1600,6 +1600,17 @@ crumb :freecen1_vld_file_manual_pob_val do |county, file|
   link 'Manual POB Validation', freecen1_vld_files_path(county: county, anchor: file)
   parent :freecen1_vld_files, session[:county], file
 end
+# .......................................freecen_pob_propagations........................................................................
+
+crumb :freecen_pob_propagations do |county|
+  link 'FreeCen POB Propagations',  freecen_pob_propagations_path
+  parent :county_options, session[:county]
+end
+
+crumb :freecen_pob_propagation do |county, file|
+  link 'FreeCen POB Propagation', freecen_pob_propagation_path(county: county)
+  parent :freecen_pob_propagations, county
+end
 
 #  .........................................................................freecen2_districts...........................................
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,6 +150,8 @@ MyopicVicar::Application.routes.draw do
   get 'freecen_csv_entries/propagate_pob', to: 'freecen_csv_entries#propagate_pob', as: :propagate_pob_freecen_csv_entry
   resources :freecen_csv_entries
 
+  resources :freecen_pob_propagations
+
   get 'messages/:id/show_waitlist_msg',:to => 'messages#show_waitlist_msg', :as => :show_waitlist_msg
   delete 'messages/:id/remove_from_useriddetail_waitlist(.:format)',:to => 'messages#remove_from_useriddetail_waitlist', :as => :remove_from_useriddetail_waitlist
   delete 'messages/:id/remove_from_userid_detail(.:format)', :to => 'messages#remove_from_userid_detail', :as => :remove_from_userid_detail

--- a/lib/freecen1_vld_pob_validator.rb
+++ b/lib/freecen1_vld_pob_validator.rb
@@ -70,7 +70,7 @@ module Freecen
           end
         end
       else
-        propagation_matches = Freecen1VldEntryPropagation.where(match_verbatim_birth_county: vld_entry.verbatim_birth_county, match_verbatim_birth_place: vld_entry.verbatim_birth_place)
+        propagation_matches = FreecenPobPropagation.where(match_verbatim_birth_county: vld_entry.verbatim_birth_county, match_verbatim_birth_place: vld_entry.verbatim_birth_place)
         if propagation_matches.present?
 
           propagation_matches.each do |prop_rec|

--- a/lib/freecen_csv_prevalidator.rb
+++ b/lib/freecen_csv_prevalidator.rb
@@ -26,7 +26,7 @@ module Freecen
 
     def update_from_propagations(csv_entry)
       match_found = false
-      propagation_match = Freecen1VldEntryPropagation.where(match_verbatim_birth_county: csv_entry.verbatim_birth_county, match_verbatim_birth_place: csv_entry.verbatim_birth_place, scope_year: 'ALL', scope_county: 'ALL').first
+      propagation_match = FreecenPobPropagation.where(match_verbatim_birth_county: csv_entry.verbatim_birth_county, match_verbatim_birth_place: csv_entry.verbatim_birth_place, scope_year: 'ALL', scope_county: 'ALL').first
       if propagation_match.present?
         if propagation_match.propagate_pob
           warning_message = csv_entry.warning_messages + "Warning: Alternate fields have been adjusted and need review.<br>"

--- a/lib/tasks/check_freecen_pob_propagations.rake
+++ b/lib/tasks/check_freecen_pob_propagations.rake
@@ -1,0 +1,37 @@
+
+task :check_freecen_pob_propagations,[:option] => :environment do
+
+  added_recs = 0
+  old_recs = Freecen1VldEntryPropagation.count
+  new_recs = FreecenPobPropagation.count
+
+  p "Freecen1VldEntryPropagation record count = #{old_recs}"
+  p "FreecenPobPropagation record count = #{new_recs}"
+
+  if old_recs == new_recs
+    p "Record counts match - no action required"
+  else
+    Freecen1VldEntryPropagation.each  do |old|
+      new = FreecenPobPropagation.where(id: old.id)
+      next if new.present?
+
+      add_prop = FreecenPobPropagation.new
+      add_prop._id = old._id
+      add_prop.scope_year = old.scope_year
+      add_prop.scope_county = old.scope_county
+      add_prop.match_verbatim_birth_county = old.match_verbatim_birth_county
+      add_prop.match_verbatim_birth_place = old.match_verbatim_birth_place
+      add_prop.new_birth_county = old.new_birth_county
+      add_prop.new_birth_place = old.new_birth_place
+      add_prop.new_notes = old.new_notes
+      add_prop.propagate_pob = old.propagate_pob
+      add_prop.propagate_notes = old.propagate_notes
+      add_prop.created_by = old.created_by
+      add_prop.save!
+      success = true
+      added_recs += 1
+
+    end
+    p "Added #{added_recs} FreecenPobPropagation records"
+  end
+end

--- a/lib/userid_role.rb
+++ b/lib/userid_role.rb
@@ -217,7 +217,7 @@ module UseridRole
     'List by uploaded date (descending)' => '/freereg1_csv_files/selection?option=List by uploaded date (descending)',
     'List files waiting to be processed' => '/freereg1_csv_files/selection?option=List files waiting to be processed',
     'Review Specific Batch' => '/freereg1_csv_files/selection?option=Review Specific Batch'
-}
+  }
   case MyopicVicar::Application.config.template_set
   when 'freereg'
     COUNTY_MANAGEMENT_OPTIONS = ['All Places', 'Active Places', 'Specific Place', 'Places with Unapproved Names', 'Review Batches with Errors',
@@ -228,7 +228,7 @@ module UseridRole
     COUNTY_MANAGEMENT_OPTIONS = ['Manage FreeCEN2 Places', 'Manage FreeCEN2 Districts', 'Manage FreeCEN2 Pieces', 'Manage FreeCEN2 Civil Parishes',
                                  'Locate Pieces', 'CAP Report','Review Batches by Filename', 'Review Batches with Errors', 'Review Batches being Validated',
                                  'Review Incorporated Batches', 'Review Specific Batch', 'Upload New Batch', 'County Statistics',
-                                 'Manage FreeCEN1 Pieces', 'Manage VLD Files', 'Manage FreeCEN1 Places']
+                                 'Manage FreeCEN1 Pieces', 'Manage VLD Files', 'Manage FreeCEN1 Places', 'Manage POB Propagations']
   when 'freebmd'
   end
   COUNTY_OPTIONS_TRANSLATION = {
@@ -258,7 +258,8 @@ module UseridRole
     'Offline Reports' => '/manage_counties/selection?option=Offline Reports',
     'Locate Pieces' => '/freecen2_pieces/enter_number',
     'CAP Report' => '/freecen2_pieces/cap_report',
-    'Clean Places UCF list' => '/manage_counties/clean_ucf_list_for_all_places'
+    'Clean Places UCF list' => '/manage_counties/clean_ucf_list_for_all_places',
+    'Manage POB Propagations' => '/freecen_pob_propagations'
   }
   COUNTY_OPTIONS_TITLES = {
     'All Places' => 'Lists all possible places in the county',
@@ -283,7 +284,8 @@ module UseridRole
     'Manage VLD Files' => 'Minimal tools to manage VLD files',
     'Manage Places' => 'Minimal tools to manage places used by CEN1',
     'Offline Reports' => 'Generate off line reports',
-    'Locate Pieces' => 'Locates Pieces in other counties, perhaps as a result of a move'
+    'Locate Pieces' => 'Locates Pieces in other counties, perhaps as a result of a move',
+    'Manage POB Propagations' => 'Manage POB Propagations'
 
   }
   case MyopicVicar::Application.config.template_set


### PR DESCRIPTION
Change the name of the FreeCen POB propagation collection as this collection is now used by VLD and CSV POB validation processes. NB Old collection is retained by this process but could be completely removed after a period of time to allow for verification of the name change.