### PR TITLE
BugID-1469

### DIFF
--- a/app/models/freereg1_csv_entry.rb
+++ b/app/models/freereg1_csv_entry.rb
@@ -203,7 +203,7 @@ class Freereg1CsvEntry
   embeds_many :embargo_records
   has_one :search_record, dependent: :restrict_with_error
 
-  before_save :add_digest, :captitalize_surnames, :check_register_type
+  before_save :sanitize_fields :add_digest, :captitalize_surnames, :check_register_type
 
   before_destroy do |entry|
     SearchRecord.destroy_all(:freereg1_csv_entry_id => entry._id)
@@ -1447,6 +1447,14 @@ class Freereg1CsvEntry
       end
     end
     return false
+  end
+
+    def sanitize_fields
+    attributes.each do |attr, value|
+      if value.is_a?(String)
+        self[attr] = value.strip
+      end
+    end
   end
 
 end

--- a/app/models/freereg1_csv_entry.rb
+++ b/app/models/freereg1_csv_entry.rb
@@ -203,7 +203,7 @@ class Freereg1CsvEntry
   embeds_many :embargo_records
   has_one :search_record, dependent: :restrict_with_error
 
-  before_save :sanitize_fields :add_digest, :captitalize_surnames, :check_register_type
+  before_save :sanitize_fields, :add_digest, :captitalize_surnames, :check_register_type
 
   before_destroy do |entry|
     SearchRecord.destroy_all(:freereg1_csv_entry_id => entry._id)

--- a/lib/tasks/sanitize_freereg1_entries.rake
+++ b/lib/tasks/sanitize_freereg1_entries.rake
@@ -1,0 +1,35 @@
+namespace :freereg do
+  desc "Trim leading/trailing whitespace from all string fields in Freereg1CsvEntry records"
+  task sanitize_existing_entries: :environment do
+    puts "Starting sanitization of Freereg1CsvEntry records..."
+    updated_count = 0
+    skipped_count = 0
+    error_count = 0
+    Freereg1CsvEntry.find_each(batch_size: 1000) do |entry|
+      begin
+        modified = false
+        entry.attributes.each do |attr, value|
+          next unless value.is_a?(String)
+          stripped = value.strip
+          if stripped != value
+            entry[attr] = stripped
+            modified = true
+          end
+        end
+        if modified
+          entry.save!(validate: false)
+          updated_count += 1
+        else
+          skipped_count += 1
+        end
+      rescue => e
+        puts "Error updating entry ID #{entry.id}: #{e.message}"
+        error_count += 1
+      end
+    end
+    puts "Sanitization complete."
+    puts "Updated records: #{updated_count}"
+    puts "Unchanged records: #{skipped_count}"
+    puts "Errors: #{error_count}"
+  end
+end


### PR DESCRIPTION
This change addresses issue 1469 by:
- Adding a `sanitize_fields` callback to `freereg1_csv_entry.rb` to strip whitespace from all string attributes before saving
- Hooking the callback into `before_save` alongside existing methods
- Providing a rake task to clean up existing records in the database so legacy data is consistent with new imports