### PR TITLE
BugID-1587

### DIFF
--- a/app/views/search_queries/_about.html.erb
+++ b/app/views/search_queries/_about.html.erb
@@ -69,6 +69,12 @@
   </p>
 </section>
 <section>
+  <h3>Parent Surnames</h3>
+  <p>
+    In some <b>FreeREG</b> baptism records, you may see <b>two surnames</b> listed — one for the <b>father</b> and one for the <b>mother</b>.
+  </p>
+</section>
+<section>
   <h3>Date</h3>
   <% if appname.downcase == 'freecen'%>
     <p>Census Criteria:

--- a/app/views/search_queries/_display_freereg_search_record_desktop.html.erb
+++ b/app/views/search_queries/_display_freereg_search_record_desktop.html.erb
@@ -5,15 +5,29 @@
       <%= viewed(@search_query,search_record) %></i>
   </td>
 <% end %>
-<td  >
+<td>
+  <% surnames = search_record[:transcript_names]
+                  .select { |n| n['type'] == 'primary' }
+                  .map { |n| n['last_name'] }
+                  .uniq
+                  .reject(&:blank?) %>
+
   <% search_record[:transcript_names].uniq.each_with_index do |name, i| %>
-    <% if  name['type'] == 'primary' %>
-      <% if i > 0 %>
-        <br />
-      <% end%>
-      <%= "#{name['first_name']} #{name['last_name']} " %>
+    <% if name['type'] == 'primary' %>
+      <% if i > 0 %><br><% end %>
+      <%= "#{name['first_name']} #{name['last_name']}" %>
     <% end %>
-  <% end%>
+  <% end %>
+
+  <% if surnames.size > 1 %>
+    <span 
+      class="tooltip-icon" 
+      data-bs-toggle="tooltip" 
+      data-bs-placement="top"
+      title="Two surnames are shown because both the mother's and father's surnames were recorded in the original register.">
+      &#9432;
+    </span>
+  <% end %>
 </td>
 <td  >
   <%= RecordType::display_name(search_record.record_type) %>


### PR DESCRIPTION
Add tooltip for records with multiple surnames in search results

- Display an info icon next to names when more than one primary surname is present.
- Tooltip explains that both the mother's and father's surnames were recorded.
- Only shows in non-print-friendly view.
- Preserves existing display of first and last names.