### PR TITLE
refactor: change groom and bride freereg1_translator order

### DIFF
--- a/lib/freereg1_translator.rb
+++ b/lib/freereg1_translator.rb
@@ -102,18 +102,18 @@ module Freereg1Translator
 
   def self.translate_names_marriage(entry)
     names = []
+      # - role: g
+    # type: primary
+    # fields:
+    # first_name: groom_forename
+    # last_name:  groom_surname
+    names << { :role => 'g', :type => 'primary', :first_name => entry.groom_forename, :last_name => entry.groom_surname }
     # - role: b
     # type: primary
     # fields:
     # first_name: bride_forename
     # last_name:  bride_surname
     names << { :role => 'b', :type => 'primary', :first_name => entry.bride_forename, :last_name => entry.bride_surname }
-    # - role: g
-    # type: primary
-    # fields:
-    # first_name: groom_forename
-    # last_name:  groom_surname
-    names << { :role => 'g', :type => 'primary', :first_name => entry.groom_forename, :last_name => entry.groom_surname }
     #
     # - role: gf
     # type: other


### PR DESCRIPTION
Translator code modified to outputs `groom` first, then `bride` -  matching the original layout on the detail page.

Need to **re-run the search record transform** on all  existing marriage records so the stored array reflects the new order.

```
# run rake task for each county

 rake freereg:reprocess_batches_for_a_county[YKS]
```

