### PR TITLE
always serve tiff scans as jpg

### DIFF
--- a/app/helpers/best_guess_helper.rb
+++ b/app/helpers/best_guess_helper.rb
@@ -126,7 +126,7 @@ module BestGuessHelper
       result
     end
   end
-  
+
   def id_to_event_type event_type
     case event_type
       when 1
@@ -319,7 +319,7 @@ private
     when '.gif'
       'GIF'
     when '.tif', '.tiff'
-      'TIFF'
+      'JPG'
     when '.pdf'
       'PDF'
     else


### PR DESCRIPTION
@VIno this was the patch I was talking about on the recent mail thread to silently serve any TIFF scans as JPEG.

It's a branch off `freebmd_development` - I hope that's the right starting point. Please can you take it from here?



> tiff scans generate support hassle for us. on freebmd1 people can select a different format if the scan's original format is tiff and they're rather smoething else. this uses an on-the-fly convertion facility provided by the image servers.
> 
> freebmd2 doesn't have a format picker so people receive a tiff regardless.
> 
> this change makes freebmd2 requests for a tiff silently convert them to jpg using the same facility as freebmd1.
> 
> it's a compromise between having a format picker on freebmd2 and people downloading tiff scans they can't use by surprise.