### PR TITLE
Fix bride mother surname unique names lookup

### DIFF
--- a/app/models/freereg1_csv_file.rb
+++ b/app/models/freereg1_csv_file.rb
@@ -1345,7 +1345,7 @@ class Freereg1CsvFile
       entries["Bride's Father's Forename"] = all_entries.distinct(:bride_father_forename).delete_if{|x| x == nil}.sort
       entries["Groom's Mother's Surname"] = all_entries.distinct(:groom_mother_surname).delete_if{|x| x == nil}.sort
       entries["Groom's Mother's Forename"] = all_entries.distinct(:groom_mother_forename).delete_if{|x| x == nil}.sort
-      entries["Bride's Mother's Surname"] = all_entries.distinct(:bride_motherr_surname).delete_if{|x| x == nil}.sort
+      entries["Bride's Mother's Surname"] = all_entries.distinct(:bride_mother_surname).delete_if{|x| x == nil}.sort
       entries["Bride's Mother's Forename"] = all_entries.distinct(:bride_mother_forename).delete_if{|x| x == nil}.sort
       entries["Witness Surname"] = all_entries.distinct('multiple_witnesses.witness_surname').delete_if{|x| x == nil}.sort
       entries["Witness Forename"] = all_entries.distinct('multiple_witnesses.witness_forename').delete_if{|x| x == nil}.sort

--- a/spec/models/freereg1_csv_file_spec.rb
+++ b/spec/models/freereg1_csv_file_spec.rb
@@ -43,6 +43,18 @@ describe Freereg1CsvFile do
     process_test_file(CHANGELESS_FILE)
   end
 
+  it "should include bride mother's surnames in the unique names list" do
+    file = Freereg1CsvFile.new(record_type: "ma")
+    all_entries = double("all entries")
+
+    allow(all_entries).to receive(:distinct).and_return([])
+    allow(all_entries).to receive(:distinct).with(:bride_mother_surname).and_return([nil, "Smith"])
+    expect(all_entries).not_to receive(:distinct).with(:bride_motherr_surname)
+    allow(Freereg1CsvEntry).to receive(:where).with(:freereg1_csv_file_id => file.id).and_return(all_entries)
+
+    file.get_unique_names["Bride's Mother's Surname"].should eq(["Smith"])
+  end
+
 
   # apparently FreeregCsvProcessor no longer returns files
   # it "should load the same file twice, correctly" do


### PR DESCRIPTION
Fixes #2901.

This updates the marriage unique names lookup to use the correctly spelled `bride_mother_surname` field for Bride's Mother's Surname, and adds a focused model spec covering the lookup.

Verification:
- `git diff --check`
- Not run: `bundle exec rspec spec/models/freereg1_csv_file_spec.rb` because this machine does not have Ruby/Bundler on PATH.