### PR TITLE
Display contract dates in FreeREG records and citations

### DIFF
--- a/app/helpers/search_records_helper.rb
+++ b/app/helpers/search_records_helper.rb
@@ -44,6 +44,10 @@ module SearchRecordsHelper
     record = record.present? ? record.titleize : record
   end
 
+  def marriage_date_for_citation(entry)
+    entry['marriage_date'].presence || entry['contract_date']
+  end
+
   def search_record_link(record)
     field = Rails.application.config.website + '/search_records/' + record
     field

--- a/app/models/freereg1_csv_entry.rb
+++ b/app/models/freereg1_csv_entry.rb
@@ -755,6 +755,9 @@ class Freereg1CsvEntry
       order = order + FreeregOptionsConstants::ORIGINAL_MARRIAGE_LAYOUT
       order = order + FreeregOptionsConstants::ORIGINAL_COMMON_FIELDS
     end
+    if contract_date.present? && !order.include?('contract_date')
+      order.insert(order.index('marriage_date') + 1, 'contract_date')
+    end
     order = order + FreeregOptionsConstants::END_FIELDS
     order = order.uniq
     order

--- a/app/views/search_records/_evidenceexplained_freereg_citation.html.erb
+++ b/app/views/search_records/_evidenceexplained_freereg_citation.html.erb
@@ -11,7 +11,7 @@
       <%=entitle(@entry['burial_date'])%>
     <%elsif record_type(@entry).downcase == "marriage"%>
       <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%>
-      <%=entitle(@entry['marriage_date'])%>
+      <%=entitle(@entry['marriage_date'].presence || @entry['contract_date'])%>
     <%end%>
     ]; citing Register number <%=@entry['register_entry_number']%>
   </p>

--- a/app/views/search_records/_evidenceexplained_freereg_citation.html.erb
+++ b/app/views/search_records/_evidenceexplained_freereg_citation.html.erb
@@ -11,7 +11,7 @@
       <%=entitle(@entry['burial_date'])%>
     <%elsif record_type(@entry).downcase == "marriage"%>
       <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%>
-      <%=entitle(@entry['marriage_date'].presence || @entry['contract_date'])%>
+      <%=entitle(marriage_date_for_citation(@entry))%>
     <%end%>
     ]; citing Register number <%=@entry['register_entry_number']%>
   </p>

--- a/app/views/search_records/_familytreemaker_freereg_citation.html.erb
+++ b/app/views/search_records/_familytreemaker_freereg_citation.html.erb
@@ -10,7 +10,7 @@
     <%elsif record_type(@entry).downcase == "burial"%>
       <%=entitle(@entry['burial_person_forename'])%> <%=entitle(@entry['burial_person_surname'])%> <%=entitle(@entry['burial_date'])%>
     <%elsif record_type(@entry).downcase == "marriage"%>
-      <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%> <%=entitle(@entry['marriage_date'].presence || @entry['contract_date'])%>
+      <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%> <%=entitle(marriage_date_for_citation(@entry))%>
     <%end%>
     <br>
     Web address:<%=search_record_link(@search_record[:_id])%>  viewed <%=Date.today.strftime("%e %b %Y")%>

--- a/app/views/search_records/_familytreemaker_freereg_citation.html.erb
+++ b/app/views/search_records/_familytreemaker_freereg_citation.html.erb
@@ -10,7 +10,7 @@
     <%elsif record_type(@entry).downcase == "burial"%>
       <%=entitle(@entry['burial_person_forename'])%> <%=entitle(@entry['burial_person_surname'])%> <%=entitle(@entry['burial_date'])%>
     <%elsif record_type(@entry).downcase == "marriage"%>
-      <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%> <%=entitle(@entry['marriage_date'])%>
+      <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%> <%=entitle(@entry['marriage_date'].presence || @entry['contract_date'])%>
     <%end%>
     <br>
     Web address:<%=search_record_link(@search_record[:_id])%>  viewed <%=Date.today.strftime("%e %b %Y")%>

--- a/app/views/search_records/_legacyfamilytree_freereg_citation.html.erb
+++ b/app/views/search_records/_legacyfamilytree_freereg_citation.html.erb
@@ -9,7 +9,7 @@
     <%elsif record_type(@entry).downcase == "burial"%>
       <%=entitle(@entry['burial_person_forename'])%> <%=entitle(@entry['burial_person_surname'])%>, <%=@entry['place']%>, <%=@entry['county']%>, UK <%=entitle(@entry['burial_date'])%>; citing  <%unless @entry['register_type'].include? "Unspecified"%><%=@entry['register_type']%><% else %>Register of unspecified type<% end %>, <%=@entry['church_name']%>
     <%elsif record_type(@entry).downcase == "marriage"%>
-      <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%>, <%=@entry['place']%>, <%=@entry['county']%>, UK <%=entitle(@entry['marriage_date'].presence || @entry['contract_date'])%>; citing  <%unless @entry['register_type'].include? "Unspecified"%><%=@entry['register_type']%><% else %>Register of unspecified type<% end %>, <%=@entry['church_name']%>
+      <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%>, <%=@entry['place']%>, <%=@entry['county']%>, UK <%=entitle(marriage_date_for_citation(@entry))%>; citing  <%unless @entry['register_type'].include? "Unspecified"%><%=@entry['register_type']%><% else %>Register of unspecified type<% end %>, <%=@entry['church_name']%>
     <%end%><br>
     <br>
     <br>

--- a/app/views/search_records/_legacyfamilytree_freereg_citation.html.erb
+++ b/app/views/search_records/_legacyfamilytree_freereg_citation.html.erb
@@ -9,7 +9,7 @@
     <%elsif record_type(@entry).downcase == "burial"%>
       <%=entitle(@entry['burial_person_forename'])%> <%=entitle(@entry['burial_person_surname'])%>, <%=@entry['place']%>, <%=@entry['county']%>, UK <%=entitle(@entry['burial_date'])%>; citing  <%unless @entry['register_type'].include? "Unspecified"%><%=@entry['register_type']%><% else %>Register of unspecified type<% end %>, <%=@entry['church_name']%>
     <%elsif record_type(@entry).downcase == "marriage"%>
-      <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%>, <%=@entry['place']%>, <%=@entry['county']%>, UK <%=entitle(@entry['marriage_date'])%>; citing  <%unless @entry['register_type'].include? "Unspecified"%><%=@entry['register_type']%><% else %>Register of unspecified type<% end %>, <%=@entry['church_name']%>
+      <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%>, <%=@entry['place']%>, <%=@entry['county']%>, UK <%=entitle(@entry['marriage_date'].presence || @entry['contract_date'])%>; citing  <%unless @entry['register_type'].include? "Unspecified"%><%=@entry['register_type']%><% else %>Register of unspecified type<% end %>, <%=@entry['church_name']%>
     <%end%><br>
     <br>
     <br>

--- a/app/views/search_records/_wikitree_freereg_citation.html.erb
+++ b/app/views/search_records/_wikitree_freereg_citation.html.erb
@@ -12,7 +12,7 @@
       <%=entitle(@entry['burial_date'])%>
     <% elsif record_type(@entry).downcase == "marriage"%>
       <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%>
-      <%=entitle(@entry['marriage_date'].presence || @entry['contract_date'])%>
+      <%=entitle(marriage_date_for_citation(@entry))%>
     <% end%>
   </p>
 </section>

--- a/app/views/search_records/_wikitree_freereg_citation.html.erb
+++ b/app/views/search_records/_wikitree_freereg_citation.html.erb
@@ -12,7 +12,7 @@
       <%=entitle(@entry['burial_date'])%>
     <% elsif record_type(@entry).downcase == "marriage"%>
       <%=entitle(@entry['groom_forename'])%> <%=entitle(@entry['groom_surname'])%> to <%=entitle(@entry['bride_forename'])%> <%=entitle(@entry['bride_surname'])%>
-      <%=entitle(@entry['marriage_date'])%>
+      <%=entitle(@entry['marriage_date'].presence || @entry['contract_date'])%>
     <% end%>
   </p>
 </section>


### PR DESCRIPTION
Fixes #2917

Summary

- Display contract_date in marriage record details when present.

- Use contract_date as a fallback in FreeREG citation formats when marriage_date is blank.

Files changed

- freereg1_csv_entry.rb

- Evidence Explained citation

- Family Tree Maker citation

- Legacy Family Tree citation

- WikiTree citation