### PR TITLE
Show clear message when no counties or syndicates can be managed

### DIFF
--- a/app/controllers/manage_counties_controller.rb
+++ b/app/controllers/manage_counties_controller.rb
@@ -189,7 +189,7 @@ class ManageCountiesController < ApplicationController
         @counties << county unless @counties.include?(county)
       end
     end
-    @counties = @counties.compact if @counties.present?
+    @counties = @counties.reject(&:blank?) if @counties.present?
     @counties.sort! if @counties.present?
   end
 

--- a/app/controllers/manage_counties_controller.rb
+++ b/app/controllers/manage_counties_controller.rb
@@ -300,7 +300,7 @@ class ManageCountiesController < ApplicationController
     get_counties_for_selection
     number_of_counties = 0
     number_of_counties = @counties.length if @counties.present?
-    redirect_back(fallback_location: new_manage_resource_path, notice: 'You do not have any counties to manage') && return if number_of_counties.zero?
+    redirect_back(fallback_location: new_manage_resource_path, notice: 'No counties/syndicates to manage.') && return if number_of_counties.zero?
 
     if number_of_counties == 1
       session[:chapman_code] = @counties[0]

--- a/app/controllers/manage_syndicates_controller.rb
+++ b/app/controllers/manage_syndicates_controller.rb
@@ -157,7 +157,6 @@ class ManageSyndicatesController < ApplicationController
       when 'freecen'
         logger.warn "FREECEN::USER #{@user.userid} has no syndicates and attempting to manage one"
       end
-      redirect_back(fallback_location: new_manage_syndicate_path, notice: 'You do not have any syndicates') && return
     end
   end
 
@@ -231,7 +230,7 @@ class ManageSyndicatesController < ApplicationController
     syndicates_for_selection
     @syndicates.blank? ? number_of_syndicates = 0 : number_of_syndicates = @syndicates.length
 
-    redirect_back(fallback_location: new_manage_resource_path, notice: 'You do not have any syndicates to manage') && return if number_of_syndicates.zero?
+    redirect_back(fallback_location: new_manage_resource_path, notice: 'No counties/syndicates to manage.') && return if number_of_syndicates.zero?
 
     if number_of_syndicates == 1
       @syndicate = @syndicates[0]

--- a/app/controllers/manage_syndicates_controller.rb
+++ b/app/controllers/manage_syndicates_controller.rb
@@ -148,7 +148,7 @@ class ManageSyndicatesController < ApplicationController
         synd << syn unless all
         synd << syn.syndicate_code if all
       end
-      @syndicates = synd
+      @syndicates = synd.reject(&:blank?)
       @syndicates.sort! if @syndicates.present?
     else
       case appname_downcase


### PR DESCRIPTION
Fixes #2912

Summary:
- Replaces generic/noisy manage-counties and manage-syndicates empty-state notices with:
  "No counties/syndicates to manage."
- Keeps the Manage buttons visible.
- Removes the early empty-syndicate redirect so the manage action handles the empty state consistently.
