### PR TITLE
Add user greeting and maintenance notice to actions view

### DIFF
--- a/app/views/manage_resources/actions.html.erb
+++ b/app/views/manage_resources/actions.html.erb
@@ -11,6 +11,7 @@
     <p><%= app %> will be undergoing some server maintenance overnight across the 9th-10th June (UK time). Logging in will be disabled, so file uploads etc. will be unavailable. Apologies for any inconvenience.</p>
   </div>
 <% end %>
+Hi <%= @user.userid %>
 <% if ['https://www.freecen.org.uk', 'https://www.freereg.org.uk', 'https://www.freebmd.org.uk'].include?(MyopicVicar::Application.config.website) %>
   <% if  @user.new_transcription_agreement.blank? || @user.new_transcription_agreement == 'Unknown' || @user.new_transcription_agreement == 'Pending' %>
     <b><%= @user.person_forename %></b><br>


### PR DESCRIPTION
Volunteers can currently only see their userid on the Profile page. When they land on the Your Actions page, there is no userid displayed, which makes it harder to identify which account they are logged in as — especially useful when coordinators manage multiple accounts.
