### PR TITLE
Add manual refresh for batch file information

### DIFF
--- a/app/controllers/freereg1_csv_files_controller.rb
+++ b/app/controllers/freereg1_csv_files_controller.rb
@@ -392,6 +392,25 @@ class Freereg1CsvFilesController < ApplicationController
     end
   end
 
+  def refresh_file_information
+    @freereg1_csv_file = Freereg1CsvFile.find(params[:id])
+    unless Freereg1CsvFile.valid_freereg1_csv_file?(params[:id])
+      message = 'The file was not correctly linked. Have your coordinator contact the web master'
+      redirect_back(fallback_location: new_manage_resource_path, notice: message) && return
+    end
+    unless @freereg1_csv_file.can_we_edit?
+      redirect_back(fallback_location: freereg1_csv_file_path(@freereg1_csv_file), notice: 'File is currently awaiting processing and should not be edited')
+      return
+    end
+
+    if @freereg1_csv_file.refresh_file_information_after_online_edit
+      flash[:notice] = 'The batch information has been recalculated'
+    else
+      flash[:notice] = "The batch information recalculation was unsuccessful: #{@freereg1_csv_file.errors.full_messages}"
+    end
+    redirect_to freereg1_csv_file_path(@freereg1_csv_file)
+  end
+
   def remove
     # this just removes a batch of records it leaves the entries and search records there to be removed by a rake task
     @freereg1_csv_file = Freereg1CsvFile.find(params[:id])

--- a/app/helpers/freereg1_csv_files_helper.rb
+++ b/app/helpers/freereg1_csv_files_helper.rb
@@ -81,6 +81,14 @@ module Freereg1CsvFilesHelper
       data: { confirm:  'Are you sure you want to reprocess this file?' }
   end
 
+  def refresh_file_information
+    return unless @freereg1_csv_file.can_we_edit?
+
+    link_to 'Refresh file status', refresh_file_information_freereg1_csv_file_path(@freereg1_csv_file),
+      class: 'btn   btn--small', method: :post,
+      data: { confirm: 'Recalculate the batch information from the current entries?' }
+  end
+
   def delete_file
     link_to 'Delete original file and all associated batch entries', freereg1_csv_file_path(@freereg1_csv_file),
       data: { confirm: 'Are you sure you want to remove this file and batch entries' }, class: 'btn   btn--small', method: :delete

--- a/app/models/freereg1_csv_file.rb
+++ b/app/models/freereg1_csv_file.rb
@@ -1056,7 +1056,9 @@ class Freereg1CsvFile
   end
 
   def refresh_file_information_after_online_edit
-    calculate_distribution && update(error: batch_errors.count)
+    calculate_distribution &&
+      update(error: batch_errors.count) &&
+      update_freereg_contents_after_processing
   end
 
   def update_number_of_files

--- a/app/models/freereg1_csv_file.rb
+++ b/app/models/freereg1_csv_file.rb
@@ -1055,6 +1055,10 @@ class Freereg1CsvFile
     end
   end
 
+  def refresh_file_information_after_online_edit
+    calculate_distribution && update(error: batch_errors.count)
+  end
+
   def update_number_of_files
     # this code although here and works produces values in fields that are no longer being used
     userid = UseridDetail.where(:userid => self.userid).first

--- a/app/views/freereg1_csv_files/_show_header.html.erb
+++ b/app/views/freereg1_csv_files/_show_header.html.erb
@@ -18,6 +18,7 @@
          'data_manager'].include?(session[:role]) %>
     <%= relocate_batch  %>
     <%= merge_batches %>
+    <%= refresh_file_information %>
     <%= reprocess_batch %>
   <% end%>
   <% if ['system_administrator','data_manager'].include?(session[:role]) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -561,6 +561,9 @@ MyopicVicar::Application.routes.draw do
   get 'freereg1_csv_files/update_registers', :to => 'freereg1_csv_files#update_registers', :as => :update_registers
   get 'freereg1_csv_files/:id/merge', :to => 'freereg1_csv_files#merge', :as => :merge_freereg1_csv_file
   get 'freereg1_csv_files/:id/remove', :to => 'freereg1_csv_files#remove', :as => :remove_freereg1_csv_file
+  post 'freereg1_csv_files/:id/refresh_file_information',
+    to: 'freereg1_csv_files#refresh_file_information',
+    as: :refresh_file_information_freereg1_csv_file
   get 'freereg1_csv_files/:id/relocate(.:format)', :to => 'freereg1_csv_files#relocate', :as => :relocate_freereg1_csv_file
   get 'freereg1_csv_files/:id/lock(.:format)', :to => 'freereg1_csv_files#lock', :as => :lock_freereg1_csv_file
   get 'freereg1_csv_files/:id/error(.:format)', :to => 'freereg1_csv_files#error', :as => :error_freereg1_csv_file

--- a/spec/models/freereg1_csv_file_spec.rb
+++ b/spec/models/freereg1_csv_file_spec.rb
@@ -81,3 +81,17 @@ describe Freereg1CsvFile do
 #         
   # end
 end
+
+describe Freereg1CsvFile, '#refresh_file_information_after_online_edit' do
+  let(:file) { Freereg1CsvFile.new }
+
+  it 'propagates recalculated file statistics to the register, church, and place' do
+    allow(file).to receive(:calculate_distribution).and_return(true)
+    allow(file).to receive(:batch_errors).and_return([])
+    allow(file).to receive(:update).with(error: 0).and_return(true)
+
+    expect(file).to receive(:update_freereg_contents_after_processing).and_return(true)
+
+    expect(file.refresh_file_information_after_online_edit).to eq(true)
+  end
+end


### PR DESCRIPTION
fixes #2880

## Summary

Adds a manual “Refresh file status” action to batch file pages.

This allows coordinators to recalculate batch file information after making online entry edits, without recalculating after every individual edit.

The refresh recalculates the file distribution and updates the stored file-level error count, which should clear stale zero-year/zero-date indicators once the underlying entry errors have been corrected.

## Background

Zero-year state is calculated through calculate_min_year, called by calculate_distribution. Previously this recalculation happened during file upload processing, but not after online edits.

## Testing

- Ruby syntax check passed for:
  - app/controllers/freereg1_csv_files_controller.rb
  - app/helpers/freereg1_csv_files_helper.rb
  - app/models/freereg1_csv_file.rb
  - config/routes.rb

## Notes

app/models/freereg1_csv_file.rb already uses CRLF line endings in master. git diff --check flags only the four newly added CRLF lines and no line-ending conversions were made.