### PR TITLE
Add contact forwarding and named CC recipients

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -109,6 +109,22 @@ class ContactsController < ApplicationController
     redirect_to(action: 'index') && return
   end
 
+  def forward_contact
+    @respond_to_contact = Contact.find(params[:source_contact_id]) if params[:source_contact_id].present?
+    redirect_back(fallback_location: contacts_path, notice: 'The contact was not found') && return if @respond_to_contact.blank?
+
+    get_user_info_from_userid
+    @message = Message.new(
+      message_time: Time.now,
+      userid: @user.userid,
+      source_contact_id: @respond_to_contact.id.to_s,
+      nature: 'contact',
+      sub_nature: 'forward',
+      subject: helpers.contact_subject(@respond_to_contact)
+    )
+    @recipient_options = UseridDetail.internal_contact_recipient_options
+  end
+
   def index
     session[:archived_contacts] = false
     session[:message_base] = 'contact'
@@ -262,7 +278,41 @@ class ContactsController < ApplicationController
     @message = Message.new
     @message.message_time = Time.now
     @message.userid = @user.userid
-    @userids = array_of_userids
+    @recipient_options = UseridDetail.internal_contact_recipient_options
+  end
+
+  def send_forward_contact
+    @respond_to_contact = Contact.find(params[:source_contact_id]) if params[:source_contact_id].present?
+    redirect_back(fallback_location: contacts_path, notice: 'The contact was not found') && return if @respond_to_contact.blank?
+
+    get_user_info_from_userid
+    @recipient_options = UseridDetail.internal_contact_recipient_options
+    selected_recipients = permitted_forward_recipients(params[:message] && params[:message][:recipients])
+    if selected_recipients.blank?
+      flash.now[:notice] = 'Please select at least one internal recipient'
+      @message = forward_message_from_params
+      render :forward_contact
+      return
+    end
+
+    @message = forward_message_from_params
+    @message.recipients = selected_recipients
+    @message.save
+    if @message.errors.any?
+      flash.now[:notice] = "The forward was not created #{@message.errors.full_messages}"
+      render :forward_contact
+      return
+    end
+
+    UserMailer.contact_forward(@respond_to_contact, @message, selected_recipients, @user.userid).deliver_now
+    @message.record_contact_forward_delivery(@user.userid, selected_recipients)
+    @message.add_message_to_userid_messages(@user)
+    selected_recipients.each do |recipient|
+      @message.add_message_to_userid_messages(UseridDetail.look_up_id(recipient))
+    end
+
+    flash[:notice] = 'Contact was forwarded'
+    redirect_to(contact_path(@respond_to_contact)) && return
   end
 
   def return_after_archive(source, id)
@@ -437,6 +487,25 @@ class ContactsController < ApplicationController
 
   def delete_reply_messages(contact_id)
     Message.where(source_contact_id: contact_id).destroy
+  end
+
+  def forward_message_from_params
+    message_params = params[:message].present? ? params.require(:message).permit(:subject, :body) : {}
+    Message.new(
+      subject: message_params[:subject].presence || helpers.contact_subject(@respond_to_contact),
+      body: message_params[:body],
+      message_time: Time.now,
+      userid: @user.userid,
+      source_contact_id: @respond_to_contact.id.to_s,
+      nature: 'contact',
+      sub_nature: 'forward'
+    )
+  end
+
+  def permitted_forward_recipients(raw_recipients)
+    selected = Array(raw_recipients).map(&:to_s).reject(&:blank?)
+    allowed = UseridDetail.internal_contact_recipient_options.map(&:last)
+    selected & allowed
   end
 
   # We store a small, non-sensitive subset of session/request context to help coordinators

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,87 @@
+# Copyright 2012 Trustees of FreeBMD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'socket'
+
+class ErrorsController < ActionController::Base
+  layout false
+
+  def not_found
+    render file: Rails.root.join('public', '404.html'), layout: false, status: :not_found
+  end
+
+  def unprocessable_entity
+    render file: Rails.root.join('public', '422.html'), layout: false, status: :unprocessable_entity
+  end
+
+  def internal_server_error
+    @error_url = error_url
+    @userid = userid
+    @server_hostname = Socket.gethostname
+
+    log_error_details
+
+    render status: :internal_server_error
+  end
+
+  private
+
+  def error_url
+    original_url = request.env['action_dispatch.original_url']
+    return original_url if original_url.present?
+
+    original_path = request.env['action_dispatch.original_path'].presence
+    original_fullpath = request.env['ORIGINAL_FULLPATH'].presence || request.env['action_dispatch.original_fullpath'].presence
+    fullpath = original_path.present? ? original_path_with_query(original_path) : original_fullpath
+    fullpath = request.original_fullpath if fullpath.blank?
+
+    if fullpath.match?(/\Ahttps?:\/\//)
+      fullpath
+    else
+      "#{request.protocol}#{request.host_with_port}#{fullpath}"
+    end
+  end
+
+  def original_path_with_query(original_path)
+    return original_path if request.query_string.blank?
+
+    "#{original_path}?#{request.query_string}"
+  end
+
+  def userid
+    userid_detail_id = session[:userid_detail_id].presence || cookies.signed[:userid].presence
+    return if userid_detail_id.blank?
+
+    userid_detail = UseridDetail.id(userid_detail_id).first
+    userid_detail.present? ? userid_detail.userid : userid_detail_id
+  rescue StandardError
+    userid_detail_id
+  end
+
+  def log_error_details
+    exception = request.env['action_dispatch.exception']
+    exception_class = exception.present? ? exception.class.name : 'Unavailable'
+    exception_message = exception.present? ? exception.message : 'Unavailable'
+
+    Rails.logger.error(
+      "500 ERROR: URL=#{@error_url} USERID=#{@userid || 'Unavailable'} " \
+      "CLIENT_IP=#{client_ip} SERVER_HOSTNAME=#{@server_hostname} " \
+      "EXCEPTION_CLASS=#{exception_class} EXCEPTION_MESSAGE=#{exception_message}"
+    )
+  end
+
+  def client_ip
+    request.remote_ip.presence || request.remote_addr.presence || 'Unavailable'
+  end
+end

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -246,7 +246,7 @@ class FeedbacksController < ApplicationController
     @message = Message.new
     @message.message_time = Time.now
     @message.userid = @user.userid
-    @userids = array_of_userids
+    @recipient_options = UseridDetail.internal_contact_recipient_options
   end
 
   def select_by_identifier

--- a/app/controllers/freereg1_csv_files_controller.rb
+++ b/app/controllers/freereg1_csv_files_controller.rb
@@ -392,6 +392,25 @@ class Freereg1CsvFilesController < ApplicationController
     end
   end
 
+  def refresh_file_information
+    @freereg1_csv_file = Freereg1CsvFile.find(params[:id])
+    unless Freereg1CsvFile.valid_freereg1_csv_file?(params[:id])
+      message = 'The file was not correctly linked. Have your coordinator contact the web master'
+      redirect_back(fallback_location: new_manage_resource_path, notice: message) && return
+    end
+    unless @freereg1_csv_file.can_we_edit?
+      redirect_back(fallback_location: freereg1_csv_file_path(@freereg1_csv_file), notice: 'File is currently awaiting processing and should not be edited')
+      return
+    end
+
+    if @freereg1_csv_file.refresh_file_information_after_online_edit
+      flash[:notice] = 'The batch information has been recalculated'
+    else
+      flash[:notice] = "The batch information recalculation was unsuccessful: #{@freereg1_csv_file.errors.full_messages}"
+    end
+    redirect_to freereg1_csv_file_path(@freereg1_csv_file)
+  end
+
   def remove
     # this just removes a batch of records it leaves the entries and search records there to be removed by a rake task
     @freereg1_csv_file = Freereg1CsvFile.find(params[:id])

--- a/app/helpers/freereg1_csv_files_helper.rb
+++ b/app/helpers/freereg1_csv_files_helper.rb
@@ -81,6 +81,14 @@ module Freereg1CsvFilesHelper
       data: { confirm:  'Are you sure you want to reprocess this file?' }
   end
 
+  def refresh_file_information
+    return unless @freereg1_csv_file.can_we_edit?
+
+    link_to 'Refresh file status', refresh_file_information_freereg1_csv_file_path(@freereg1_csv_file),
+      class: 'btn   btn--small', method: :post,
+      data: { confirm: 'Recalculate the batch information from the current entries?' }
+  end
+
   def delete_file
     link_to 'Delete original file and all associated batch entries', freereg1_csv_file_path(@freereg1_csv_file),
       data: { confirm: 'Are you sure you want to remove this file and batch entries' }, class: 'btn   btn--small', method: :delete

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -136,6 +136,19 @@ class UserMailer < Devise::Mailer
     mail(from: sender_email_address, cc: copies_to_userids_emails,to: "#{@contact.name} <#{@contact.email_address}>", bcc: @cc_email_addresses, subject: @message.subject)
   end
 
+
+  def contact_forward(contact, message, recipient_userids, sender_userid)
+    @appname = appname
+    @contact = contact
+    @message = message
+    @forwarder = UseridDetail.userid(sender_userid).first
+    @forwarder_name = @forwarder.present? ? "#{@forwarder.person_forename} #{@forwarder.person_surname}" : sender_userid
+    @contact_url = "#{Rails.application.config.website}/contacts/#{@contact.id}"
+    sender_email_address = get_email_address_from_userid(sender_userid)
+    recipient_email_addresses = get_email_address_array_from_array_of_userids(recipient_userids)
+    mail(from: sender_email_address, to: recipient_email_addresses, subject: "Forwarded contact: #{@message.subject}")
+  end
+
   def coordinator_feedback_reply(feedback, ccs_userids, message, sender_userid)
     @appname = appname
     @feedback = feedback

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -146,6 +146,7 @@ class UserMailer < Devise::Mailer
     @contact_url = "#{Rails.application.config.website}/contacts/#{@contact.id}"
     sender_email_address = get_email_address_from_userid(sender_userid)
     recipient_email_addresses = get_email_address_array_from_array_of_userids(recipient_userids)
+    get_attachment(@contact)
     mail(from: sender_email_address, to: recipient_email_addresses, subject: "Forwarded contact: #{@message.subject}")
   end
 

--- a/app/models/freereg1_csv_file.rb
+++ b/app/models/freereg1_csv_file.rb
@@ -1055,6 +1055,10 @@ class Freereg1CsvFile
     end
   end
 
+  def refresh_file_information_after_online_edit
+    calculate_distribution && update(error: batch_errors.count)
+  end
+
   def update_number_of_files
     # this code although here and works produces values in fields that are no longer being used
     userid = UseridDetail.where(:userid => self.userid).first

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -325,6 +325,18 @@ class Message
     end
   end
 
+
+  def record_contact_forward_delivery(sender_userid, recipient_userids)
+    sent_message = SentMessage.new(
+      message_id: id,
+      sender: sender_userid,
+      recipients: recipient_userids,
+      sent_time: Time.now
+    )
+    sent_messages << [sent_message]
+    sent_message.save
+  end
+
   def restore
     update_attribute(:archived, false)
     Message.message_replies(id).each do |message_rl1|

--- a/app/models/userid_detail.rb
+++ b/app/models/userid_detail.rb
@@ -170,6 +170,20 @@ class UseridDetail
     end
 
 
+
+    def internal_contact_recipient_options
+      roles = FreeregOptionsConstants::COMMUNICATION_ROLES
+      users = UseridDetail.active(true).email_address_valid.where(:email_address.nin => [nil, '']).any_of(
+        { :person_role.in => roles },
+        { :secondary_role.in => roles }
+      ).order_by(person_surname: 1, person_forename: 1, userid_lower_case: 1)
+
+      users.map do |user|
+        role_label = ([user.person_role] + Array(user.secondary_role)).compact.uniq.select { |role| roles.include?(role) }.join(', ')
+        ["#{user.person_forename} #{user.person_surname} (#{user.userid}) — #{role_label}", user.userid]
+      end
+    end
+
     def uploaded_freecen_file(users, transcribers)
       uploaded = []
       FreecenCsvFile.where(:userid.exists => true).each do |file|

--- a/app/views/contacts/_list_contacts.html.erb
+++ b/app/views/contacts/_list_contacts.html.erb
@@ -27,6 +27,7 @@
                 <td>
                   <%= link_to 'Show', contact_path(feedback.id, source: params[:action]),  :class => "btn btn--small", method: :get%>
                   <%= link_to 'Reply', reply_contact_path(source_contact_id:feedback.id) ,:class => "btn btn--small" %>
+                  <%= link_to 'Forward', forward_contact_path(source_contact_id:feedback.id) ,:class => "btn btn--small" %>
                   <%= link_to 'View Replies', contact_reply_messages_path(feedback.id), class: "btn btn--small", method: :get if feedback.has_replies?(feedback.id.to_s)%>
                   <%= link_to 'Keep until I say so', keep_contact_path(feedback.id), :class => 'btn btn--small',  data: { confirm: 'Are you sure you want keep this contact' } unless feedback.keep.present? %>
                   <%= link_to 'Archive', archive_contact_path(feedback.id, source: params[:action]), :class => "btn btn--small",  data: { confirm: 'Are you sure you want archive this contact' } unless feedback.is_archived?%>

--- a/app/views/contacts/_show_nav.html.erb
+++ b/app/views/contacts/_show_nav.html.erb
@@ -1,5 +1,6 @@
 <div  class=" text--center push--bottom">
   <%= link_to 'Create Reply', reply_contact_path(source_contact_id:@contact.id) ,:class => "btn btn--small" %>
+  <%= link_to 'Forward', forward_contact_path(source_contact_id:@contact.id) ,:class => "btn btn--small" %>
   <%= show_contact_add_comment_link(@contact, params[:source])%>
   <%= link_to 'View Replies', contact_reply_messages_path(@contact.id), class: "btn btn--small", method: :get %>
   <%= link_to 'Archive', archive_contact_path(@contact.id), :class => "btn btn--small", data: { confirm: 'Are you sure you want to Archive this contact?' } if do_we_show_archive_contact_action?(@contact)%>

--- a/app/views/contacts/forward_contact.html.erb
+++ b/app/views/contacts/forward_contact.html.erb
@@ -1,0 +1,45 @@
+<% breadcrumb :create_contact_reply,  @respond_to_contact%>
+<% if flash[:notice] %>
+  <div id="notice" style="color:blue"><br>
+    <%= flash[:notice] %>  <% flash[:notice] = nil%><br>
+  </div>
+<% end %>
+<h4 style="text-align: center">Forward Contact Reference <%= @respond_to_contact.identifier %></h4>
+<div class= "grid">
+  <section class="island  island--light ">
+    <div class="scrollable" >
+      <div class="grid__item  one-whole  palm-one-whole push--bottom">
+        <%= content_tag :p, class: "strong" do %>
+          On <%= @respond_to_contact.contact_time.to_formatted_s(:long)%> <%= @respond_to_contact.name%> (<%= @respond_to_contact.email_address %>) submitted a <%= @respond_to_contact.contact_type %>.<br>
+          The contact information was:<br>
+        <% end %>
+        <%= @respond_to_contact.body %>
+      </div>
+    </div>
+  </section>
+</div>
+<div class= "grid">
+  <section class="island  island--light ">
+    <%= semantic_form_for(@message, url: send_forward_contact_path(source_contact_id: @respond_to_contact.id), html: { multipart: true }) do |f| %>
+      <%= f.hidden_field :message_time %>
+      <%= f.hidden_field :userid %>
+      <%= f.hidden_field :source_contact_id, value: @respond_to_contact.id %>
+      <%= f.hidden_field :sub_nature, value: 'forward' %>
+      <ul>
+        <li class="grid__item one-whole palm-one-whole push--bottom">
+          <label class="label" for="message_recipients">Forward to</label>
+          <%= select_tag 'message[recipients]', options_for_select(@recipient_options), multiple: true, class: 'select', size: 8, required: true %>
+        </li>
+        <li class="grid__item one-whole palm-one-whole push--bottom" id="subject_input" >
+          <label class="label" for="subject">Subject </label>
+          <%= text_field_tag 'message[subject]', @message.subject, class: 'text-input flush--bottom', readonly: true, title: @message.subject %>
+        </li>
+        <li class="grid__item one-whole palm-one-whole push--bottom">
+          <label>Forwarding note<span class="weight--normal"> (optional)</span></label>
+          <textarea name="message[body]" style="width: 100%;" rows="8"><%= @message.body %></textarea>
+        </li>
+      </ul>
+      <%= f.action :submit, as: :input, label: 'Forward Contact', button_html: {class: 'btn'}, wrapper_html: { class: 'grid__item one-whole text--center' } %>
+    <% end %>
+  </section>
+</div>

--- a/app/views/contacts/forward_contact.html.erb
+++ b/app/views/contacts/forward_contact.html.erb
@@ -14,6 +14,18 @@
           The contact information was:<br>
         <% end %>
         <%= @respond_to_contact.body %>
+        <% attachment_file_paths = @respond_to_contact.attachment_file_paths %>
+        <% if attachment_file_paths.present? %>
+          <div class="push--top">
+            <p class="strong">Attachments will be forwarded with this contact.</p>
+            <p>This contact has <%= pluralize(attachment_file_paths.count, 'attachment') %>:</p>
+            <ul>
+              <% attachment_file_paths.each do |attachment_file_path| %>
+                <li><%= File.basename(attachment_file_path) %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
       </div>
     </div>
   </section>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>We're sorry, but something went wrong (500)</title>
+  <style type="text/css">
+    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
+    div.dialog {
+      width: 25em;
+      padding: 0 4em;
+      margin: 4em auto 0 auto;
+      border: 1px solid #ccc;
+      border-right-color: #999;
+      border-bottom-color: #999;
+    }
+    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+    dl { text-align: left; }
+    dt { font-weight: bold; margin-top: 1em; }
+    dd { margin-left: 0; word-break: break-word; }
+  </style>
+</head>
+
+<body>
+  <div class="dialog">
+    <h1>We're sorry, but something went wrong with processing your request. A report has been produced and sent to the webmaster. Please return to your prior activity but try to avoid doing the exact same action again.</h1>
+    <dl>
+      <dt>URL</dt>
+      <dd><%= @error_url %></dd>
+      <% if @userid.present? %>
+        <dt>Userid</dt>
+        <dd><%= @userid %></dd>
+      <% end %>
+      <dt>Server hostname</dt>
+      <dd><%= @server_hostname %></dd>
+    </dl>
+  </div>
+</body>
+</html>

--- a/app/views/freereg1_csv_files/_show_header.html.erb
+++ b/app/views/freereg1_csv_files/_show_header.html.erb
@@ -18,6 +18,7 @@
          'data_manager'].include?(session[:role]) %>
     <%= relocate_batch  %>
     <%= merge_batches %>
+    <%= refresh_file_information %>
     <%= reprocess_batch %>
   <% end%>
   <% if ['system_administrator','data_manager'].include?(session[:role]) %>

--- a/app/views/messages/_form_for_contact.html.erb
+++ b/app/views/messages/_form_for_contact.html.erb
@@ -21,8 +21,8 @@
         </li>
         <% if params.has_key?(:source_contact_id) || params.has_key?(:source_feedback_id)  %>
          <li class="grid__item  one-half  palm-one-whole push--bottom push--top">
-            <label>Copies to Userids<span  class="weight--normal"> (optional)</span><a href="#" class="right_tooltip"> <%= image_tag 'png/info.png', alt: 'Information', height: '16' %><span style="width: 900%" >Please the userids to send copies to</span></a></label>
-            <%= select_tag 'message[copies_to_userids]',options_for_select(@userids), multiple: true, prompt: 'None', class: 'select', size: 5 %>
+            <label>Copies to internal recipients<span  class="weight--normal"> (optional)</span><a href="#" class="right_tooltip"> <%= image_tag 'png/info.png', alt: 'Information', height: '16' %><span style="width: 900%" >Please select the internal recipients to send copies to</span></a></label>
+            <%= select_tag 'message[copies_to_userids]',options_for_select(@recipient_options || @userids), multiple: true, prompt: 'None', class: 'select', size: 5 %>
           </li>
         <% end %>
         <li class="grid__item  one-whole  palm-one-whole push--bottom">

--- a/app/views/user_mailer/contact_forward.html.erb
+++ b/app/views/user_mailer/contact_forward.html.erb
@@ -4,6 +4,9 @@
 
 <p><b>Subject:</b> <%= @message.subject %></p>
 <p><b>Contact link:</b> <a href="<%= @contact_url %>"><%= @contact_url %></a></p>
+<% if @contact.contact_time.present? %>
+  <p><b>Original enquiry received:</b> <%= @contact.contact_time.strftime('%d %b %Y') %></p>
+<% end %>
 
 <% if @message.body.present? %>
   <p><b>Forwarding note:</b></p>

--- a/app/views/user_mailer/contact_forward.html.erb
+++ b/app/views/user_mailer/contact_forward.html.erb
@@ -1,0 +1,16 @@
+<p>Dear <%= @appname %> team member,</p>
+
+<p><%= @forwarder_name %> forwarded contact reference <%= @contact.identifier %> for your attention.</p>
+
+<p><b>Subject:</b> <%= @message.subject %></p>
+<p><b>Contact link:</b> <a href="<%= @contact_url %>"><%= @contact_url %></a></p>
+
+<% if @message.body.present? %>
+  <p><b>Forwarding note:</b></p>
+  <p><%= @message.body %></p>
+<% end %>
+
+<p><b>Original contact from <%= @contact.name %> &lt;<%= @contact.email_address %>&gt;:</b></p>
+<p><%= @contact.body %></p>
+
+<p>The <%= @appname %> Team</p>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,6 +34,7 @@ MyopicVicar::Application.configure do
   # Full error reports are disabled and caching is turned on
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
+  config.exceptions_app = routes
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
   config.serve_static_files = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -561,6 +561,9 @@ MyopicVicar::Application.routes.draw do
   get 'freereg1_csv_files/update_registers', :to => 'freereg1_csv_files#update_registers', :as => :update_registers
   get 'freereg1_csv_files/:id/merge', :to => 'freereg1_csv_files#merge', :as => :merge_freereg1_csv_file
   get 'freereg1_csv_files/:id/remove', :to => 'freereg1_csv_files#remove', :as => :remove_freereg1_csv_file
+  post 'freereg1_csv_files/:id/refresh_file_information',
+    to: 'freereg1_csv_files#refresh_file_information',
+    as: :refresh_file_information_freereg1_csv_file
   get 'freereg1_csv_files/:id/relocate(.:format)', :to => 'freereg1_csv_files#relocate', :as => :relocate_freereg1_csv_file
   get 'freereg1_csv_files/:id/lock(.:format)', :to => 'freereg1_csv_files#lock', :as => :lock_freereg1_csv_file
   get 'freereg1_csv_files/:id/error(.:format)', :to => 'freereg1_csv_files#error', :as => :error_freereg1_csv_file

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,6 +276,8 @@ MyopicVicar::Application.routes.draw do
   get 'contacts/select_by_identifier',  :to => 'contacts#select_by_identifier', :as => :select_by_identifier_contacts
   get 'contacts/:id(.:format)/report_error', :to => 'contacts#report_error', :as => :report_error_contact
   get 'contacts/:source_contact_id/reply',  :to => 'contacts#reply_contact', :as => :reply_contact
+  get 'contacts/:source_contact_id/forward',  :to => 'contacts#forward_contact', :as => :forward_contact
+  post 'contacts/:source_contact_id/forward',  :to => 'contacts#send_forward_contact', :as => :send_forward_contact
   get 'contacts/:id/contact_reply_messages', to: 'contacts#contact_reply_messages', as: :contact_reply_messages
   get 'contacts/:id/force_destroy',  :to => 'contacts#force_destroy', :as => :force_destroy_contact
   get 'contacts/:id/archive',  :to => 'contacts#archive', :as => :archive_contact

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,10 @@ MyopicVicar::Application.routes.draw do
 
 
   root :to => 'search_queries#new'
+  match '/404', to: 'errors#not_found', via: :all
+  match '/422', to: 'errors#unprocessable_entity', via: :all
+  match '/500', to: 'errors#internal_server_error', via: :all
+
   resources :reminder_to_donate
   resources :donate_cta_feedback
 

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -1,0 +1,61 @@
+# Copyright 2012 Trustees of FreeBMD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'spec_helper'
+
+RSpec.describe ErrorsController, type: :controller do
+  describe 'GET internal_server_error' do
+    let(:exception) { RuntimeError.new('private failure') }
+    let(:logger) { instance_double(ActiveSupport::Logger, error: true) }
+
+    before do
+      request.env['action_dispatch.exception'] = exception
+      request.env['action_dispatch.original_path'] = '/problem'
+      request.env['QUERY_STRING'] = 'source=original'
+      request.env['REMOTE_ADDR'] = '203.0.113.12'
+      session[:userid_detail_id] = 'abc123'
+
+      allow(Rails).to receive(:logger).and_return(logger)
+      allow(Socket).to receive(:gethostname).and_return('test-host')
+      allow(UseridDetail).to receive(:id).with('abc123').and_return(double(first: double(userid: 'testuserid')))
+    end
+
+    it 'renders public-safe error details' do
+      get :internal_server_error
+
+      expect(response.status).to eq(500)
+      expect(response.body).to include('http://test.host/problem?source=original')
+      expect(response.body).to include('testuserid')
+      expect(response.body).to include('test-host')
+      expect(response.body).not_to include('RuntimeError')
+      expect(response.body).not_to include('private failure')
+      expect(response.body).not_to include('203.0.113.12')
+    end
+
+    it 'logs the diagnostic error details' do
+      get :internal_server_error
+
+      expect(logger).to have_received(:error).with(
+        a_string_including(
+          'URL=http://test.host/problem?source=original',
+          'USERID=testuserid',
+          'CLIENT_IP=203.0.113.12',
+          'SERVER_HOSTNAME=test-host',
+          'EXCEPTION_CLASS=RuntimeError',
+          'EXCEPTION_MESSAGE=private failure'
+        )
+      )
+    end
+  end
+end

--- a/spec/mailers/user_mailer_contact_forward_spec.rb
+++ b/spec/mailers/user_mailer_contact_forward_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe UserMailer, type: :mailer do
+  describe '#contact_forward' do
+    let(:contact) do
+      Contact.new(
+        identifier: '12345',
+        name: 'Public Sender',
+        email_address: 'public@example.org',
+        body: 'Original contact body',
+        contact_type: 'General Comment',
+        contact_time: Time.zone.now
+      )
+    end
+
+    let(:message) do
+      Message.new(
+        subject: 'RE: Contact subject',
+        body: 'Please handle this',
+        userid: 'sender1',
+        sub_nature: 'forward'
+      )
+    end
+
+    let(:sender) do
+      double('sender', person_forename: 'Alice', person_surname: 'Sender', email_address: 'alice@example.org')
+    end
+
+    let(:recipient) do
+      double('recipient', email_address: 'coord@example.org')
+    end
+
+    before do
+      allow(UseridDetail).to receive(:userid).with('sender1').and_return(double(first: sender))
+      allow(UseridDetail).to receive(:userid).with('coord1').and_return(double(first: recipient))
+      allow(Rails.application.config).to receive(:website).and_return('https://www.freereg.org.uk')
+    end
+
+    it 'sends only to selected internal recipients' do
+      mail = described_class.contact_forward(contact, message, ['coord1'], 'sender1')
+
+      expect(mail.to).to eq(['coord@example.org'])
+      expect(mail.cc).to be_blank
+      expect(mail.bcc).to be_blank
+      expect(mail.to).not_to include('public@example.org')
+      expect(mail.subject).to include('Forwarded contact')
+    end
+
+    it 'includes the contact context and forwarding note' do
+      mail = described_class.contact_forward(contact, message, ['coord1'], 'sender1')
+
+      expect(mail.body.encoded).to include('Original contact body')
+      expect(mail.body.encoded).to include('Please handle this')
+      expect(mail.body.encoded).to include('12345')
+    end
+  end
+end

--- a/spec/mailers/user_mailer_contact_forward_spec.rb
+++ b/spec/mailers/user_mailer_contact_forward_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.body.encoded).to include('Original contact body')
       expect(mail.body.encoded).to include('Please handle this')
       expect(mail.body.encoded).to include('12345')
+      expect(mail.body.encoded).to include(contact.contact_time.strftime('%d %b %Y'))
+    end
+
+    it 'includes the original contact attachments' do
+      allow(contact).to receive(:attachment_file_paths).and_return(['/tmp/first.png', '/tmp/second.pdf'])
+      allow(File).to receive(:binread).with('/tmp/first.png').and_return('first attachment')
+      allow(File).to receive(:binread).with('/tmp/second.pdf').and_return('second attachment')
+
+      mail = described_class.contact_forward(contact, message, ['coord1'], 'sender1')
+
+      expect(mail.attachments.map(&:filename)).to contain_exactly('first.png', 'second.pdf')
     end
   end
 end

--- a/spec/models/message_contact_forward_spec.rb
+++ b/spec/models/message_contact_forward_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe Message do
+  describe '#record_contact_forward_delivery' do
+    it 'records a sent internal forward delivery' do
+      message = described_class.create!(subject: 'Forwarded contact', body: 'Please handle this', nature: 'contact', sub_nature: 'forward')
+      message.record_contact_forward_delivery('sender1', ['coord1'])
+
+      sent = message.sent_messages.first
+      expect(sent.sender).to eq('sender1')
+      expect(sent.recipients).to eq(['coord1'])
+      expect(sent.sent_time).to be_present
+    end
+  end
+end

--- a/spec/models/userid_detail_contact_recipient_options_spec.rb
+++ b/spec/models/userid_detail_contact_recipient_options_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+RSpec.describe UseridDetail do
+  describe '.internal_contact_recipient_options' do
+    let(:valid_user) do
+      described_class.new(
+        userid: 'coord1',
+        userid_lower_case: 'coord1',
+        person_forename: 'Ann',
+        person_surname: 'Coordinator',
+        person_role: 'contacts_coordinator',
+        secondary_role: [],
+        active: true,
+        email_address_valid: true
+      )
+    end
+
+    let(:inactive_user) do
+      described_class.new(
+        userid: 'inactive1',
+        userid_lower_case: 'inactive1',
+        person_forename: 'Ian',
+        person_surname: 'Inactive',
+        person_role: 'contacts_coordinator',
+        secondary_role: [],
+        active: false,
+        email_address_valid: true
+      )
+    end
+
+    let(:invalid_email_user) do
+      described_class.new(
+        userid: 'invalid1',
+        userid_lower_case: 'invalid1',
+        person_forename: 'Eve',
+        person_surname: 'Invalid',
+        person_role: 'contacts_coordinator',
+        secondary_role: [],
+        active: true,
+        email_address_valid: false
+      )
+    end
+
+    it 'returns named active internal recipients with userid values' do
+      relation = double('recipient relation')
+      allow(described_class).to receive(:active).with(true).and_return(relation)
+      allow(relation).to receive(:email_address_valid).and_return(relation)
+      allow(relation).to receive(:where).and_return(relation)
+      allow(relation).to receive(:any_of).and_return(relation)
+      allow(relation).to receive(:order_by).and_return([valid_user])
+
+      expect(described_class.internal_contact_recipient_options).to eq([
+        ['Ann Coordinator (coord1) — contacts_coordinator', 'coord1']
+      ])
+    end
+
+    it 'queries only active users with valid email addresses' do
+      relation = double('recipient relation')
+      allow(described_class).to receive(:active).with(true).and_return(relation)
+      allow(relation).to receive(:email_address_valid).and_return(relation)
+      allow(relation).to receive(:where).and_return(relation)
+      allow(relation).to receive(:any_of).and_return(relation)
+      allow(relation).to receive(:order_by).and_return([valid_user])
+
+      described_class.internal_contact_recipient_options
+
+      expect(described_class).to have_received(:active).with(true)
+      expect(relation).to have_received(:email_address_valid)
+      expect(relation).to have_received(:where).with(:email_address.nin => [nil, ''])
+      expect(relation).to have_received(:any_of)
+    end
+  end
+end

--- a/spec/views/contact_forward_views_spec.rb
+++ b/spec/views/contact_forward_views_spec.rb
@@ -1,6 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe 'contact forward views', type: :view do
+  describe 'contacts/_show_nav.html.erb' do
+    it 'renders Forward alongside contact actions' do
+      contact = double('contact', id: 'contact1', keep: nil)
+      assign(:contact, contact)
+      allow(view).to receive(:show_contact_add_comment_link).and_return('')
+      allow(view).to receive(:do_we_show_archive_contact_action?).and_return(true)
+      allow(view).to receive(:do_we_show_restore_contact_action?).and_return(false)
+      allow(view).to receive(:do_we_show_github_create_contact_action?).and_return(false)
+
+      render partial: 'contacts/show_nav'
+
+      expect(rendered).to include('Create Reply')
+      expect(rendered).to include('Forward')
+      expect(rendered).to include('Archive')
+      expect(rendered).to include('/contacts/contact1/forward')
+    end
+  end
+
   describe 'contacts/_list_contacts.html.erb' do
     it 'renders Forward beside Reply' do
       contact = double(
@@ -26,14 +44,57 @@ RSpec.describe 'contact forward views', type: :view do
 
   describe 'contacts/forward_contact.html.erb' do
     it 'shows named recipients while using userid values' do
-      assign(:respond_to_contact, Contact.new(identifier: '12345', name: 'Public Sender', email_address: 'public@example.org', body: 'Original contact body', contact_type: 'General Comment', contact_time: Time.zone.now))
-      assign(:message, Message.new(subject: 'RE: Contact subject'))
-      assign(:recipient_options, [['Ann Coordinator (coord1) — contacts_coordinator', 'coord1']])
+      assign_forward_contact(forward_contact)
 
       render template: 'contacts/forward_contact'
 
       expect(rendered).to include('Ann Coordinator (coord1) — contacts_coordinator')
       expect(rendered).to include('value="coord1"')
+    end
+
+    it 'does not show an attachment notice when there are no attachments' do
+      contact = forward_contact
+      allow(contact).to receive(:attachment_file_paths).and_return([])
+      assign_forward_contact(contact)
+
+      render template: 'contacts/forward_contact'
+
+      expect(rendered).not_to include('Attachments will be forwarded')
+      expect(rendered).not_to include('This contact has')
+    end
+
+    it 'shows the filename when one attachment will be forwarded' do
+      contact = forward_contact
+      allow(contact).to receive(:attachment_file_paths).and_return(['/tmp/contact evidence.png'])
+      assign_forward_contact(contact)
+
+      render template: 'contacts/forward_contact'
+
+      expect(rendered).to include('Attachments will be forwarded with this contact.')
+      expect(rendered).to include('This contact has 1 attachment')
+      expect(rendered).to include('contact evidence.png')
+    end
+
+    it 'shows the count and filenames when multiple attachments will be forwarded' do
+      contact = forward_contact
+      allow(contact).to receive(:attachment_file_paths).and_return(['/tmp/first.png', '/tmp/second.pdf'])
+      assign_forward_contact(contact)
+
+      render template: 'contacts/forward_contact'
+
+      expect(rendered).to include('This contact has 2 attachments')
+      expect(rendered).to include('first.png')
+      expect(rendered).to include('second.pdf')
+    end
+
+    it 'does not display a missing attachment path as an attachment' do
+      contact = forward_contact(screenshot_location: 'uploads/contact/screenshots/contact1/missing.png')
+      assign_forward_contact(contact)
+
+      render template: 'contacts/forward_contact'
+
+      expect(rendered).not_to include('Attachments will be forwarded')
+      expect(rendered).not_to include('missing.png')
     end
   end
 
@@ -48,5 +109,22 @@ RSpec.describe 'contact forward views', type: :view do
       expect(rendered).to include('Ann Coordinator (coord1) — contacts_coordinator')
       expect(rendered).to include('value="coord1"')
     end
+  end
+
+  def forward_contact(attributes = {})
+    Contact.new({
+      identifier: '12345',
+      name: 'Public Sender',
+      email_address: 'public@example.org',
+      body: 'Original contact body',
+      contact_type: 'General Comment',
+      contact_time: Time.zone.now
+    }.merge(attributes))
+  end
+
+  def assign_forward_contact(contact)
+    assign(:respond_to_contact, contact)
+    assign(:message, Message.new(subject: 'RE: Contact subject'))
+    assign(:recipient_options, [['Ann Coordinator (coord1) — contacts_coordinator', 'coord1']])
   end
 end

--- a/spec/views/contact_forward_views_spec.rb
+++ b/spec/views/contact_forward_views_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe 'contact forward views', type: :view do
+  describe 'contacts/_list_contacts.html.erb' do
+    it 'renders Forward beside Reply' do
+      contact = double(
+        'contact',
+        id: 'contact1',
+        name: 'Public Sender',
+        email_address: 'public@example.org',
+        contact_type: 'General Comment',
+        county: nil,
+        contact_time: Time.zone.now,
+        keep: nil,
+        identifier: '12345',
+        has_replies?: false,
+        is_archived?: false
+      )
+
+      render partial: 'contacts/list_contacts', locals: { contacts: [contact], text: 'active' }
+
+      expect(rendered).to include('Reply')
+      expect(rendered).to include('Forward')
+    end
+  end
+
+  describe 'contacts/forward_contact.html.erb' do
+    it 'shows named recipients while using userid values' do
+      assign(:respond_to_contact, Contact.new(identifier: '12345', name: 'Public Sender', email_address: 'public@example.org', body: 'Original contact body', contact_type: 'General Comment', contact_time: Time.zone.now))
+      assign(:message, Message.new(subject: 'RE: Contact subject'))
+      assign(:recipient_options, [['Ann Coordinator (coord1) — contacts_coordinator', 'coord1']])
+
+      render template: 'contacts/forward_contact'
+
+      expect(rendered).to include('Ann Coordinator (coord1) — contacts_coordinator')
+      expect(rendered).to include('value="coord1"')
+    end
+  end
+
+  describe 'messages/_form_for_contact.html.erb' do
+    it 'renders named CC options with userid values' do
+      params[:source_contact_id] = 'contact1'
+      assign(:message, Message.new)
+      assign(:recipient_options, [['Ann Coordinator (coord1) — contacts_coordinator', 'coord1']])
+
+      render partial: 'messages/form_for_contact'
+
+      expect(rendered).to include('Ann Coordinator (coord1) — contacts_coordinator')
+      expect(rendered).to include('value="coord1"')
+    end
+  end
+end


### PR DESCRIPTION
for #2565

## Summary
- add a Forward action for contact inquiries with internal named-recipient selection
- add an internal-only contact forward mailer and Message/SentMessage audit record
- update contact and feedback reply CC selectors to show named internal recipients while submitting userids
- add focused model, mailer, and view specs for the new forward/recipient behavior

Closes #2565

## Checks
- ruby -c app/controllers/contacts_controller.rb
- ruby -c app/controllers/feedbacks_controller.rb
- ruby -c app/mailers/user_mailer.rb
- ruby -c app/models/message.rb
- ruby -c app/models/userid_detail.rb
- ruby -c config/routes.rb
- ruby -c on new spec files
- git diff --check

## Notes
- Focused rspec command could not run examples locally because MongoDB was unavailable at localhost:27017.
- Raw CLI ERB syntax checking fails on existing Rails/Formtastic block-output templates such as semantic_form_for; checked unchanged limitation separately.