### PR TITLE
config - turn on `log_tags` so we log request id in the rails log

### DIFF
--- a/config/initializers/log_tags.rb
+++ b/config/initializers/log_tags.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
+
+# Tag every log line with the request id so the log tailer can join "Processing
+# by X#y" to its "Completed ... in Nms" line. Required because Puma interleaves
+# requests across threads.
 #
-# Tag every log line with the request id so the log tailer can join
-# "Processing by X#y" to its "Completed ... in Nms" line. Required because
-# Puma interleaves requests across threads.
-#
-# Set here rather than in config/environments/production.rb: config/initializers/*
-# run during the railtie phase, and the middleware stack (which reads
-# config.log_tags when constructing Rails::Rack::Logger) is built afterwards,
-# in the finisher phase.
+# Set here rather than in config/environments/production.rb:
+# config/initializers/* run during the railtie phase, and the middleware stack
+# (which reads config.log_tags when constructing Rails::Rack::Logger) is built
+# afterwards, in the finisher phase.
+
 Rails.application.config.log_tags = [:request_id]

--- a/config/initializers/log_tags.rb
+++ b/config/initializers/log_tags.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+#
+# Tag every log line with the request id so the log tailer can join
+# "Processing by X#y" to its "Completed ... in Nms" line. Required because
+# Puma interleaves requests across threads.
+#
+# Set here rather than in config/environments/production.rb: config/initializers/*
+# run during the railtie phase, and the middleware stack (which reads
+# config.log_tags when constructing Rails::Rack::Logger) is built afterwards,
+# in the finisher phase.
+Rails.application.config.log_tags = [:request_id]


### PR DESCRIPTION
the request id comes from X-Request-Id header set as a uuid by HAProxy
or Apache. This lets us match Processed and Completed lines that are
otherwise intermingled.

tested on, and removed from, rails1:~apache/hosts/freereg2/production

Example log with tags enabled:

```
[aldx7CrFrxhJXYYAK6vkdQAAAEQ] Started GET "/" for a.b.c.d at 2026-07-15 12:41:32 +0100
[aldx7CrFrxhJXYYAK6vkdQAAAEQ] Processing by SearchQueriesController#new as */*
[aldx7CrFrxhJXYYAK6vkdQAAAEQ]   Rendered search_queries/new.html.erb within layouts/application (Duration: 3.6ms | Allocations: 7568)
[aldx7CrFrxhJXYYAK6vkdQAAAEQ]   Rendered layout layouts/application.html.erb (Duration: 6.4ms | Allocations: 12002)
[aldx7CrFrxhJXYYAK6vkdQAAAEQ] Completed 200 OK in 10ms (Views: 6.7ms | MongoDB: 1.5ms | Allocations: 13447)
```
