### PR TITLE
Fix incorrect completion submitted image group notice

### DIFF
--- a/app/controllers/manage_counties_controller.rb
+++ b/app/controllers/manage_counties_controller.rb
@@ -222,7 +222,7 @@ class ManageCountiesController < ApplicationController
     session.delete(:from_source)
     session[:image_group_filter] = 'completion_submitted'
     @source, @group_ids, @group_id = ImageServerGroup.group_ids_sort_by_place(session[:chapman_code], 'completion_submitted')            # not sort by place, unallocated groups
-    redirect_back(fallback_location: new_manage_resource_path, notice: 'No Allocate Request Image Groups exists') && return if @source.blank? || @group_ids.blank? || @group_id.blank?
+    redirect_back(fallback_location: new_manage_resource_path, notice: "No image groups found with status of 'Completion Submitted'") && return if @source.blank? || @group_ids.blank? || @group_id.blank?
 
     @county = session[:county]
     # for 'Accept All Groups As Completed'

--- a/spec/controllers/manage_counties_controller_spec.rb
+++ b/spec/controllers/manage_counties_controller_spec.rb
@@ -1,0 +1,40 @@
+# Copyright 2012 Trustees of FreeBMD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'spec_helper'
+
+RSpec.describe ManageCountiesController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
+  describe 'GET manage_completion_submitted_image_group' do
+    before do
+      user = User.new(id: BSON::ObjectId.new, userid_detail_id: BSON::ObjectId.new.to_s)
+      sign_in user
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+
+    it 'redirects with a status-specific notice when no image groups exist' do
+      session[:chapman_code] = 'NFK'
+      allow(controller).to receive(:get_user_info_from_userid)
+      expect(ImageServerGroup).to receive(:group_ids_sort_by_place)
+        .with('NFK', 'completion_submitted')
+        .and_return([[], [], {}])
+
+      get :manage_completion_submitted_image_group
+
+      expect(response).to have_http_status(:redirect)
+      expect(flash[:notice]).to eq("No image groups found with status of 'Completion Submitted'")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #2963.

Corrects the message shown when no image groups have a status of `completion_submitted`.

The previous message incorrectly referred to Allocate Request image groups. The notice now says:

> No image groups found with status of 'Completion Submitted'

## Testing

- Added focused controller coverage for the empty-result path.
- Verified the completion-submitted status filter is passed to `ImageServerGroup.group_ids_sort_by_place`.
- Confirmed the redirect and corrected flash notice.

## Checks

- `bundle exec rspec spec/controllers/manage_counties_controller_spec.rb`
- `ruby -c app/controllers/manage_counties_controller.rb`
- `ruby -c spec/controllers/manage_counties_controller_spec.rb`
- `git diff --check`