### PR TITLE
Fix Image Server bulk action redirect loops

### DIFF
--- a/app/controllers/image_server_groups_controller.rb
+++ b/app/controllers/image_server_groups_controller.rb
@@ -241,6 +241,7 @@ class ImageServerGroupsController < ApplicationController
 
         ImageServerGroup.email_cc_completion(x, @place.chapman_code, @user)
       end
+      redirect_to(manage_image_group_manage_syndicate_path, :notice => 'Email sent to County Coordinator') && return
     end
 
     redirect_back(fallback_location: new_manage_resource_path, :notice => 'Email sent to County Coordinator')
@@ -270,7 +271,9 @@ class ImageServerGroupsController < ApplicationController
       user = get_user
       flash[:notice] = ImageServerGroup.update_put_request(params, user)
 
-      if params[:type] == 'complete'
+      if params[:type] == 'complete' && params[:completed_groups].present?
+        redirect_to manage_image_group_manage_county_path
+      elsif params[:type] == 'complete'
         redirect_to manage_completion_submitted_image_group_manage_county_path(session[:chapman_code])
       else
         redirect_to index_image_server_group_path(image_server_group.source)

--- a/app/controllers/manage_counties_controller.rb
+++ b/app/controllers/manage_counties_controller.rb
@@ -222,7 +222,7 @@ class ManageCountiesController < ApplicationController
     session.delete(:from_source)
     session[:image_group_filter] = 'completion_submitted'
     @source, @group_ids, @group_id = ImageServerGroup.group_ids_sort_by_place(session[:chapman_code], 'completion_submitted')            # not sort by place, unallocated groups
-    redirect_back(fallback_location: new_manage_resource_path, notice: "No image groups found with status of 'Completion Submitted'") && return if @source.blank? || @group_ids.blank? || @group_id.blank?
+    redirect_to(manage_image_group_manage_county_path, notice: "No image groups found with status of 'Completion Submitted'") && return if @source.blank? || @group_ids.blank? || @group_id.blank?
 
     @county = session[:county]
     # for 'Accept All Groups As Completed'

--- a/app/controllers/manage_syndicates_controller.rb
+++ b/app/controllers/manage_syndicates_controller.rb
@@ -171,7 +171,7 @@ class ManageSyndicatesController < ApplicationController
     @source, @group_ids, @group_id = ImageServerGroup.group_ids_by_syndicate(session[:syndicate], 'r')
     @completed_groups = []
     @group_ids.each { |x| @completed_groups << x[0] } if @group_ids.present?
-    redirect_back(fallback_location: manage_image_group_manage_syndicate_path(session[:syndicate]), notice: 'No Fully Reviewed Image Groups Under This Syndicate') && return if @source.blank? || @group_ids.blank? || @group_id.blank?
+    redirect_to(manage_image_group_manage_syndicate_path, notice: 'No Fully Reviewed Image Groups Under This Syndicate') && return if @source.blank? || @group_ids.blank? || @group_id.blank?
 
     # added for 'email CC of all image groups' button under 'List Fully Reviewed Groups'
     session.delete(:from_source)
@@ -187,7 +187,7 @@ class ManageSyndicatesController < ApplicationController
     # added for 'email CC of all image groups' button under 'List Fully Transcribed Groups'
     @completed_groups = []
     @group_ids.each { |x| @completed_groups << x[0] } if @group_ids.present?
-    redirect_back(fallback_location: manage_image_group_manage_syndicate_path(session[:syndicate]), notice: 'No Fully Transcribed Image Groups Under This Syndicate') && return if @source.blank? || @group_ids.blank? || @group_id.blank?
+    redirect_to(manage_image_group_manage_syndicate_path, notice: 'No Fully Transcribed Image Groups Under This Syndicate') && return if @source.blank? || @group_ids.blank? || @group_id.blank?
 
     session.delete(:from_source)
     session[:image_group_filter] = 'fully_transcribed'

--- a/app/views/manage_syndicates/list_fully_reviewed_group.html.erb
+++ b/app/views/manage_syndicates/list_fully_reviewed_group.html.erb
@@ -7,7 +7,7 @@
 <div class="grid">
   <% if not @group_ids.empty? %>
     <div style="text-align: center">
-      <%= link_to 'Email CC of All Image Groups', send_complete_to_cc_image_server_group_path(:completed_groups=>@completed_groups), method: :get, :class => "btn  btn--small" %>
+      <%= button_to 'Email CC of All Image Groups', send_complete_to_cc_image_server_groups_path, method: :post, params: { completed_groups: @completed_groups }, class: "btn  btn--small" %>
     </div>
   <% end %>
   <section class="island">

--- a/app/views/manage_syndicates/list_fully_transcribed_group.html.erb
+++ b/app/views/manage_syndicates/list_fully_transcribed_group.html.erb
@@ -7,7 +7,7 @@
 <div class="grid">
   <% if not @group_ids.empty? %>
     <div style="text-align: center">
-      <%= link_to 'Email CC of All Image Groups', send_complete_to_cc_image_server_group_path(:completed_groups=>@completed_groups), method: :get, :class => "btn  btn--small" %>
+      <%= button_to 'Email CC of All Image Groups', send_complete_to_cc_image_server_groups_path, method: :post, params: { completed_groups: @completed_groups }, class: "btn  btn--small" %>
     </div>
   <% end %>
   <section class="island">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -654,6 +654,7 @@ MyopicVicar::Application.routes.draw do
   get 'image_server_groups/upload_return', :to => 'image_server_groups#upload_return', :as => :upload_return_image_server_group
   get 'image_server_groups/:id/request_cc_image_server_group(.:format)', :to => 'image_server_groups#request_cc_image_server_group', :as => :request_cc_image_server_group
   get 'image_server_groups/:id/request_sc_image_server_group(.:format)', :to => 'image_server_groups#request_sc_image_server_group', :as => :request_sc_image_server_group
+  post 'image_server_groups/send_complete_to_cc(.:format)', :to => 'image_server_groups#send_complete_to_cc', :as => :send_complete_to_cc_image_server_groups
   get 'image_server_groups/:id/send_complete_to_cc(.:format)', :to => 'image_server_groups#send_complete_to_cc', :as => :send_complete_to_cc_image_server_group
   resources :image_server_groups
 

--- a/spec/controllers/image_server_groups_controller_spec.rb
+++ b/spec/controllers/image_server_groups_controller_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+RSpec.describe ImageServerGroupsController, type: :controller do
+  before do
+    allow(controller).to receive(:require_login)
+  end
+
+  describe "POST send_complete_to_cc" do
+    it "emails every selected group once, transitions via the existing model method, and redirects to the syndicate image server page" do
+      session[:syndicate] = "SYN"
+      user = double("user")
+      place = double("place", chapman_code: "NFK")
+      allow(controller).to receive(:display_info) do
+        controller.instance_variable_set(:@user, user)
+        controller.instance_variable_set(:@place, place)
+      end
+      expect(ImageServerGroup).to receive(:email_cc_completion).with("group-1", "NFK", user).once
+      expect(ImageServerGroup).to receive(:email_cc_completion).with("group-2", "NFK", user).once
+
+      post :send_complete_to_cc, params: { completed_groups: ["group-1", "group-2"] }
+
+      expect(response).to redirect_to(manage_image_group_manage_syndicate_path)
+      expect(flash[:notice]).to eq("Email sent to County Coordinator")
+    end
+  end
+
+  describe "PUT update" do
+    it "uses the existing bulk completion update and redirects to the county image server page" do
+      user = double("user")
+      relation = double("relation", first: double("image server group"))
+      allow(controller).to receive(:get_user).and_return(user)
+      allow(ImageServerGroup).to receive(:id).with("group-1").and_return(relation)
+      expect(ImageServerGroup).to receive(:update_put_request).with(
+        hash_including("type" => "complete", "completed_groups" => ["group-1", "group-2"]),
+        user
+      ).and_return("updated")
+
+      put :update, params: { id: "group-1", _method: "put", type: "complete", completed_groups: ["group-1", "group-2"] }
+
+      expect(response).to redirect_to(manage_image_group_manage_county_path)
+      expect(flash[:notice]).to eq("updated")
+    end
+  end
+end

--- a/spec/controllers/manage_counties_controller_spec.rb
+++ b/spec/controllers/manage_counties_controller_spec.rb
@@ -31,9 +31,12 @@ RSpec.describe ManageCountiesController, type: :controller do
         .with('NFK', 'completion_submitted')
         .and_return([[], [], {}])
 
+      request.env["HTTP_REFERER"] = "http://test.host/manage_counties/manage_completion_submitted_image_group"
+
       get :manage_completion_submitted_image_group
 
-      expect(response).to have_http_status(:redirect)
+      expect(response).to redirect_to(manage_image_group_manage_county_path)
+      expect(response.location).not_to eq(request.env["HTTP_REFERER"])
       expect(flash[:notice]).to eq("No image groups found with status of 'Completion Submitted'")
     end
   end

--- a/spec/controllers/manage_syndicates_controller_spec.rb
+++ b/spec/controllers/manage_syndicates_controller_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe ManageSyndicatesController, type: :controller do
+  before do
+    allow(controller).to receive(:require_login)
+    allow(controller).to receive(:get_user_info_from_userid)
+    session[:syndicate] = "SYN"
+  end
+
+  {
+    list_fully_transcribed_group: "No Fully Transcribed Image Groups Under This Syndicate",
+    list_fully_reviewed_group: "No Fully Reviewed Image Groups Under This Syndicate"
+  }.each do |action, notice|
+    it "redirects an empty #{action} list to the syndicate image server page, not its referrer" do
+      allow(ImageServerGroup).to receive(:group_ids_by_syndicate).and_return([[], [], {}])
+      request.env["HTTP_REFERER"] = "http://test.host/manage_syndicates/SYN/#{action}"
+
+      get action, params: { id: "SYN" }
+
+      expect(response).to redirect_to(manage_image_group_manage_syndicate_path)
+      expect(response.location).not_to eq(request.env["HTTP_REFERER"])
+      expect(flash[:notice]).to eq(notice)
+    end
+  end
+end

--- a/spec/models/image_server_group_spec.rb
+++ b/spec/models/image_server_group_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+RSpec.describe ImageServerGroup, type: :model do
+  describe ".email_cc_completion" do
+    it "marks the group completion submitted and sends one email" do
+      group = double("group criteria")
+      delivery = double("delivery")
+      allow(described_class).to receive(:where).with(id: "group-1").and_return(group)
+      expect(ImageServerImage).to receive(:update_image_status).with(group, "cs").once
+      expect(UserMailer).to receive(:notify_cc_assignment_complete)
+        .with("user", "group-1", "NFK").once.and_return(delivery)
+      expect(delivery).to receive(:deliver_now).once
+
+      described_class.email_cc_completion("group-1", "NFK", "user")
+    end
+  end
+
+  describe ".update_put_request" do
+    it "marks every selected group completed" do
+      initial = double("initial relation", first: double("initial group"))
+      group_1 = double("group 1 relation")
+      group_2 = double("group 2 relation")
+      allow(described_class).to receive(:id).with("group-1").and_return(initial, group_1)
+      allow(described_class).to receive(:id).with("group-2").and_return(group_2)
+      expect(group_1).to receive(:update_image_and_group_for_put_request).with("r", "c").once
+      expect(group_2).to receive(:update_image_and_group_for_put_request).with("r", "c").once
+
+      described_class.update_put_request(
+        { id: "group-1", type: "complete", completed_groups: ["group-1", "group-2"] },
+        "user"
+      )
+    end
+  end
+end

--- a/spec/routing/image_server_groups_routing_spec.rb
+++ b/spec/routing/image_server_groups_routing_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe ImageServerGroupsController, type: :routing do
+  it "routes bulk completion email through POST without a group id" do
+    expect(post: "/image_server_groups/send_complete_to_cc").to route_to(
+      controller: "image_server_groups",
+      action: "send_complete_to_cc"
+    )
+    expect(get: "/image_server_groups/group-1/send_complete_to_cc").to route_to(
+      controller: "image_server_groups",
+      action: "send_complete_to_cc",
+      id: "group-1"
+    )
+    expect(get: "/image_server_groups/send_complete_to_cc").not_to route_to(
+      controller: "image_server_groups",
+      action: "send_complete_to_cc"
+    )
+  end
+end

--- a/spec/views/manage_syndicates/bulk_email_forms_spec.rb
+++ b/spec/views/manage_syndicates/bulk_email_forms_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.shared_examples "a bulk image-group email form" do
+  before do
+    session[:syndicate] = "SYN"
+    assign(:group_ids, [["group-1"], ["group-2"]])
+    assign(:completed_groups, ["group-1", "group-2"])
+    allow(view).to receive(:render).and_call_original
+    allow(view).to receive(:render).with(partial: "flash_notice").and_return("")
+    allow(view).to receive(:render).with(
+      partial: "image_groups",
+      locals: { image_group_filter: kind_of(String) }
+    ).and_return("")
+  end
+
+  it "posts group ids in the request body rather than the URL" do
+    render
+
+    expect(rendered).to include(%(action="#{send_complete_to_cc_image_server_groups_path}"))
+    expect(rendered).to include(%(method="post"))
+    expect(rendered).to include(%(name="completed_groups[]" value="group-1"))
+    expect(rendered).to include(%(name="completed_groups[]" value="group-2"))
+    expect(rendered).not_to include("?completed_groups")
+  end
+end
+
+RSpec.describe "manage_syndicates/list_fully_transcribed_group.html.erb", type: :view do
+  it_behaves_like "a bulk image-group email form"
+end
+
+RSpec.describe "manage_syndicates/list_fully_reviewed_group.html.erb", type: :view do
+  it_behaves_like "a bulk image-group email form"
+end


### PR DESCRIPTION
## Summary

Fixes #2987.

The Image Server bulk actions could redirect back to lists that had become empty after processing every displayed group. Those empty-list actions also used `redirect_back`, allowing the browser to redirect repeatedly to the same page or back to the bulk action.

## Changes

- Added a dedicated POST collection route for bulk County Coordinator emails.
- Changed the two bulk-email controls to native POST forms.
- Submitted group IDs in the request body instead of the URL.
- Redirected bulk email and bulk completion actions to stable Image Server parent pages.
- Replaced `redirect_back` in the affected empty-list branches with explicit parent-page redirects.
- Preserved the existing individual email action and completion behaviour.

## Tests

Added coverage for:

- bulk email routing without a group ID;
- POST form generation and request-body parameters;
- exactly-once email processing;
- email and completion status transitions;
- stable county and syndicate redirects;
- empty-list handling with a self-referencing referrer.

Final focused test result:

10 examples, 0 failures