### PR TITLE
Fixes #2903 Added the Location of Source Documents field church db 

### DIFF
--- a/app/models/church.rb
+++ b/app/models/church.rb
@@ -20,6 +20,7 @@ class Church
   field :contributors, type: Hash
   field :unique_surnames, type: Array
   field :unique_forenames, type: Array
+  field :location_of_source_documents, type: String
   has_many :registers, dependent: :restrict_with_error
   has_many :image_server_groups
   embeds_many :alternatechurchnames

--- a/app/views/churches/_form.html.erb
+++ b/app/views/churches/_form.html.erb
@@ -11,6 +11,7 @@
   <%= f.input :location, :label => "The Church Location :", :input_html => {:class => " simple_form_bgcolour simple_form_position overide_selection_field_width",:size => 60 }%>
   <%= f.input :website, :label => "The Church Website :", :input_html => {:class => " simple_form_bgcolour simple_form_position overide_selection_field_width",:size => 60 }%>
   <%= f.input :church_notes, :label => "Notes about the church :",as: :text, :input_html => { :rows => 5, :columns =>30 , :placeholder => "Enter your notes", :class => " simple_form_bgcolour simple_form_position overide_selection_field_width"} %>
+  <%= f.input :location_of_source_documents, :label => "Location of Source Documents :", :as => :text, :hint => "Enter the names of all archives that hold the registers of this church, along with the catalogue numbers for each set of registers. Do the same for documents that are not church registers (e.g., parish minute books).", :input_html => { :rows => 5, :columns => 30, :class => " simple_form_bgcolour simple_form_position overide_selection_field_width" } %>
   <%= f.input :last_amended, :label => "Last date when data for the place was updated", :hint =>"System generated ",:input_html => { :disabled => true, :size => 20  }%>
   <%= f.button :submit, 'Submit'   %>
 <% end %>

--- a/app/views/churches/show.html.erb
+++ b/app/views/churches/show.html.erb
@@ -51,6 +51,10 @@
             <td class="weight--semibold"> <%= @church.church_notes %> </td>
           </tr>
           <tr>
+            <td>Location of Source Documents :</td>
+            <td class="weight--semibold"> <%= @church.location_of_source_documents %> </td>
+          </tr>
+          <tr>
             <td>Latest date a transcription changed:</td>
             <td class="weight--semibold"> <%= @church.last_amended %></td>
           </tr>

--- a/app/views/freereg_contents/_church.html.erb
+++ b/app/views/freereg_contents/_church.html.erb
@@ -52,5 +52,9 @@
       <td>Notes about the Church </td>
       <td class='weight--semibold' > <%= (@church.church_notes) %> </td>
     </tr>
+    <tr>
+      <td>Location of Source Documents </td>
+      <td class='weight--semibold' > <%= (@church.location_of_source_documents) %> </td>
+    </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
Feat #2903.
Added the Location of Source Documents field (`location_of_source_documents`) to the Church model, input form, management view, and public view pages.

## Changes
Model
- Added `location_of_source_documents` field to the MongoDB Church model (`app/models/church.rb`).

View
- `app/views/churches/_form.html.erb`: Added input field with accessible inline hint text.
- `app/views/churches/show.html.erb`: Displayed field on the management view page.
- `app/views/freereg_contents/church.html.erb`: Displayed field on the public church view page.