### PR TITLE
Preserve line breaks in Contact/Feedback body text (fixes #1380)

### DIFF
--- a/app/helpers/contacts_helper.rb
+++ b/app/helpers/contacts_helper.rb
@@ -59,14 +59,21 @@ module ContactsHelper
   end
 
   def format_contact_body_for_display(contact)
-    body = contact&.body.to_s
-    return ''.html_safe if body.blank?
+    format_body_for_display(contact&.body)
+  end
+
+  # Renders free-text body content (Contact/Message/Feedback) with paragraph and line breaks
+  # preserved. Uses simple_format rather than CSS white-space, since several email clients
+  # (e.g. Gmail) strip that CSS property and would otherwise collapse the layout back down.
+  def format_body_for_display(text)
+    text = text.to_s
+    return ''.html_safe if text.blank?
 
     content_tag(
       :div,
-      body,
+      simple_format(text),
       class: 'contact-body-formatted read-length',
-      style: 'white-space: pre-wrap; word-wrap: break-word; max-width: 48rem;'
+      style: 'word-wrap: break-word; max-width: 48rem;'
     )
   end
 

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -6,7 +6,7 @@
   </div>
 <% end %>
 <%= simple_form_for  @contact   do |f| %>
-  <%= f.input :body, :label => "Comments ",as: :text, :input_html => { :rows => 5, :cols =>40 , :placeholder => @contact.body} %>
+  <%= f.input :body, :label => "Comments ",as: :text, :input_html => { :rows => 5, :cols =>40 , wrap: "hard", :placeholder => @contact.body} %>
   <%= f.input :record_url, :label => "Record URL", as: :url, :input_html => { :placeholder => @contact.record_url} %>
   <%= f.button :submit, 'Submit'   %>
 <% end %>

--- a/app/views/contacts/reply_contact.html.erb
+++ b/app/views/contacts/reply_contact.html.erb
@@ -14,7 +14,7 @@
           We sent the communication to <%= @respond_to_contact.contact_action_sent_to_userid%> for action.
           The contact information was:<br>
         <% end %>
-        <%= @respond_to_contact.body %>
+        <%= simple_format(@respond_to_contact.body) %>
       </div>
     </div>
   </section>
@@ -38,7 +38,7 @@
                 </strong>
               <% end%>
             <% end %>
-            <%= reply.body %>
+            <%= simple_format(reply.body) %>
             <% if reply.attachment.present?%>
               <br/>
               <span>Attachment: </span>

--- a/app/views/contacts/report_error/_form_block_main_contact.html.erb
+++ b/app/views/contacts/report_error/_form_block_main_contact.html.erb
@@ -18,7 +18,7 @@
   </li>
   <li class="grid__item one-whole lap-one-whole palm-one-whole">
     <label class="label ttip" for="contact_report_body" tabindex="0" id="contact_report_body_label">Additional comments (optional)</label>
-    <textarea id="contact_report_body" name="contact[body]" class="text-input" rows="4" cols="40" placeholder="Anything else we should know (optional if you filled corrections above)."><%= @contact.body %></textarea>
+    <textarea id="contact_report_body" name="contact[body]" class="text-input" wrap="hard" rows="4" cols="40" placeholder="Anything else we should know (optional if you filled corrections above)."><%= @contact.body %></textarea>
   </li>
   <li class="grid__item one-third lap-three-fifths lap-clear--left palm-one-whole">
     <label class="label ttip" for="screenshot" tabindex="0">Screenshot or image <span class="weight--normal"> (optional)</span></label>

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 <%= simple_form_for(@feedback, :html => {:multipart => true}) do |f| %>
   <%= f.input :title, :label => "Summary" , :input_html => {:class => "simple_form_bgcolour ", :size => 40 }%>
-  <%= f.input :body, :label =>"Description" ,as: :text, :input_html => { :class => "simple_form_bgcolour ",:rows => 10, :cols =>60 , :placeholder => "Enter your comments"}%>
+  <%= f.input :body, :label =>"Description" ,as: :text, :input_html => { :class => "simple_form_bgcolour ",:rows => 10, :cols =>60 , wrap: "hard", :placeholder => "Enter your comments"}%>
   <%= f.input :feedback_nature, required: true, include_blank:'Select the feedback type', label:  "Nature of feedback",  collection: [['Problem/Bug', 'bug'], ['Improvement/Suggestion', 'website']], :input_html => {class: "simple_form_bgcolour overide_selection_field_width", prompt:"Choose the feedback type, include_blank: false, required: true"} %>
   <%= f.input :screenshot, :label => "Screenshot: Only jpg, jpeg, png or gif file" %>
   <%= f.input :feedback_time, :as => :hidden %>

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -7,6 +7,6 @@
 <% end %>
 <%= simple_form_for  @feedback   do |f| %>
   <%= f.input :title,  :label => "Title ", :input_html => { :class => " simple_form_bgcolour  ",:size => 30, :placeholder => @feedback.title} %>
-  <%= f.input :body, :label => "Comments ",as: :text, :input_html => {:class => "simple_form_bgcolour overide_selection_field_width", :rows => 5, :cols =>50 , :placeholder => @feedback.body} %>
+  <%= f.input :body, :label => "Comments ",as: :text, :input_html => {:class => "simple_form_bgcolour overide_selection_field_width", :rows => 5, :cols =>50 , wrap: "hard", :placeholder => @feedback.body} %>
   <%= f.button :submit, 'Submit'   %>
 <% end %>

--- a/app/views/feedbacks/reply_feedback.html.erb
+++ b/app/views/feedbacks/reply_feedback.html.erb
@@ -15,8 +15,7 @@
           We sent it to <%= @respond_to_feedback.contact_action_sent_to_userid%> for action.
           The contact information was:<br>
         <% end %>
-        <%= @respond_to_feedback.body %><br>
-        <br>
+        <%= simple_format(@respond_to_feedback.body) %>
         <p><b>Further details of the feedback follow:</b></p>
         <div class="scrollable">
           <table class= "table--bordered table--data push--bottom t100">
@@ -63,7 +62,7 @@
                 </strong>
               <% end%>
             <% end %>
-            <%= reply.body %>
+            <%= simple_format(reply.body) %>
             <% if reply.attachment.present?%>
               <br/>
               <span>Attachment: </span>

--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -21,7 +21,7 @@
         <%#= render 'show_actor' %>
         <tr>
           <td>The explanation was:</td>
-          <td class="weight--semibold"><%= @feedback.body %></td>
+          <td class="weight--semibold"><%= simple_format(@feedback.body) %></td>
         </tr>
         <tr>
           <td>Session Data:</td>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -35,9 +35,9 @@
         <li class="grid__item  one-whole  palm-one-whole push--bottom">
           <label>Message (a salutation is not required but a personal sign off would be nice)</label>
           <% if @message.body.nil? %>
-            <textarea name="message[body]"  style="width: 100%;"  rows="8" ></textarea>
+            <textarea name="message[body]"  style="width: 100%;" wrap="hard" cols="80"  rows="8" ></textarea>
           <% else%>
-            <textarea name="message[body]"  style="width: 100%;"  rows="8" ><%=@message.body%></textarea>
+            <textarea name="message[body]"  style="width: 100%;" wrap="hard" cols="80"  rows="8" ><%=@message.body%></textarea>
           <% end%>
         </li>
       </ul>

--- a/app/views/messages/_form_for_contact.html.erb
+++ b/app/views/messages/_form_for_contact.html.erb
@@ -22,9 +22,9 @@
         <li class="grid__item  one-whole  palm-one-whole push--bottom">
           <label>Message<a href="#" class="right_tooltip"> <%= image_tag 'png/info.png', alt: 'Information', height: '16' %><span  >You should include a salutation at the start</span></a></label>
           <% if @message.body.nil? %>
-            <textarea name="message[body]"  style="width: 100%;"  rows="8" ></textarea>
+            <textarea name="message[body]"  style="width: 100%;" wrap="hard" cols="80"  rows="8" ></textarea>
           <% else%>
-            <textarea name="message[body]"  style="width: 100%;"  rows="8" ><%=@message.body%></textarea>
+            <textarea name="message[body]"  style="width: 100%;" wrap="hard" cols="80"  rows="8" ><%=@message.body%></textarea>
           <% end%>
         </li>
       </ul>

--- a/app/views/user_mailer/acknowledge_communication.html.erb
+++ b/app/views/user_mailer/acknowledge_communication.html.erb
@@ -16,7 +16,7 @@
   <p><b>Missing entry</b> (as submitted on the form):</p>
   <%= render partial: 'contacts/freebmd_missing_entry_table', locals: { rows: freebmd_missing_entry_rows(@communication) } %>
 <% end %>
-<div style="white-space:pre-wrap;word-wrap:break-word;font-family:system-ui,Segoe UI,sans-serif;font-size:14px;line-height:1.45;max-width:48rem;"><%= @communication.body %></div>
+<div style="word-wrap:break-word;font-family:system-ui,Segoe UI,sans-serif;font-size:14px;line-height:1.45;max-width:48rem;"><%= simple_format(@communication.body) %></div>
 <% if @appname.downcase == 'freecen'%>
   <% if @communication.contact_type == 'Data Problem'%>
     <%= render 'cen_coordinator_data_problem'%>

--- a/app/views/user_mailer/acknowledge_donate_cta_feedback.html.erb
+++ b/app/views/user_mailer/acknowledge_donate_cta_feedback.html.erb
@@ -2,5 +2,5 @@
 <p>Thank you for your feedback. Please quote the following number <%= @communication.identifier %> in any subsequent communication with us on this matter.</p>
 <p>A member of our team will review the feedback and should respond as soon as we can. If they determine that a system change may be appropriate then the feedback will be referred to the by-weekly project management for priorization along with other issues and feature requests. </p>
 <p>The following is the information you submitted.</p>
-<p>  <%= @communication.body %></p>
+<%= simple_format(@communication.body) %>
 <p>The <%= @appname %> Team</p>

--- a/app/views/user_mailer/acknowledge_feedback.html.erb
+++ b/app/views/user_mailer/acknowledge_feedback.html.erb
@@ -3,7 +3,7 @@
 <p>A member of our team will review the feedback and should respond as soon as we can. If they determine that a system change may be appropriate then the feedback will be referred to the by-weekly project management for priorization along with other issues and feature requests. </p>
 <p>The following is the information you submitted.</p>
 <p>  <b><%= @communication.feedback_type %>:</b></p>
-<p>  <%= @communication.body %></p>
+<%= simple_format(@communication.body) %>
 <% if @communication.screenshot_url.present?%>
   <p>A copy of any attachment is provided.</p>
 <% end%>

--- a/app/views/user_mailer/communicate_donate_cta_feedback.html.erb
+++ b/app/views/user_mailer/communicate_donate_cta_feedback.html.erb
@@ -2,6 +2,6 @@
 <p>We have received correspondence for our <%=@appname%> donate CTA <%= @communication.identifier %> from <%= @communication.name %> email <%= @communication.email_address %>. </p>
 
 Following is the information submitted.</p>
-<p>  <%= @communication.body %></p>
+<%= simple_format(@communication.body) %>
 <p>The <%= @appname %> Team</p>
 </p>

--- a/app/views/user_mailer/contact_action_request.html.erb
+++ b/app/views/user_mailer/contact_action_request.html.erb
@@ -23,7 +23,7 @@
   <p><b>Missing entry</b> (as submitted on the form):</p>
   <%= render partial: 'contacts/freebmd_missing_entry_table', locals: { rows: freebmd_missing_entry_rows(@contact) } %>
 <% end %>
-<div style="white-space:pre-wrap;word-wrap:break-word;font-family:system-ui,Segoe UI,sans-serif;font-size:14px;line-height:1.45;max-width:48rem;"><%= @contact.body %></div>
+<div style="word-wrap:break-word;font-family:system-ui,Segoe UI,sans-serif;font-size:14px;line-height:1.45;max-width:48rem;"><%= simple_format(@contact.body) %></div>
 <% if @contact.contact_type == 'Data Problem' &&  @contact.entry_id.present?%>
   <p><a href="<%=Rails.application.config.website%>/freereg1_csv_entries/<%=@contact.entry_id%>"> <%=@contact.line_id %> </a></p>
 <% end%>

--- a/app/views/user_mailer/coordinator_contact_reply.html.erb
+++ b/app/views/user_mailer/coordinator_contact_reply.html.erb
@@ -3,7 +3,7 @@
   <a href="<%=Rails.application.config.website%>/contacts/<%=@contact.id%>"><%= @contact.identifier %></a>
   at <%= @contact.contact_time.strftime("%H:%M on %F") unless @contact.contact_time.nil?%></p>
 <p>A team member has replied as follows:</p>
-<p><%= @message.body%></p>
+<%= simple_format(@message.body) %>
 <% if @message.attachment.present?%>
   There is an File attachment
 <% end%>

--- a/app/views/user_mailer/coordinator_feedback_reply.html.erb
+++ b/app/views/user_mailer/coordinator_feedback_reply.html.erb
@@ -3,7 +3,7 @@
   <a href="<%=Rails.application.config.website%>/feedbacks/<%=@feedback.id%>"><%= @feedback.identifier %></a>
   to us with the title <b><%= @feedback.title%></b> at <%= @feedback.feedback_time.strftime("%H:%M on %F") unless @feedback.feedback_time.nil?%></p>
 <p>A team member has replied as follows:</p>
-<p><%= @message.body%></p>
+<%= simple_format(@message.body) %>
 <% if @message.attachment.present?%>
   There is an File attachment
 <% end%>

--- a/app/views/user_mailer/feedback_action_request.html.erb
+++ b/app/views/user_mailer/feedback_action_request.html.erb
@@ -10,7 +10,7 @@
 <% end%>
 <p>The following is the information submitted <a href="<%=Rails.application.config.website%>/feedbacks/<%=@contact.id%>">On line access</a></p>
 <p>  <b><%= @contact.feedback_type %>:</b></p>
-<p>  <%= @contact.body %></p>
+<%= simple_format(@contact.body) %>
 <% if @contact.screenshot_url.present?%>
   <p>An image/attachment is provided</p>
 <% end%>

--- a/app/views/user_mailer/message_reply.html.erb
+++ b/app/views/user_mailer/message_reply.html.erb
@@ -4,5 +4,5 @@
 <p>On the initial landing page after the log in; select the "Messages" button and on the list of messages select the "Show" for specific message identification <%=@reply.identifier%>.</p>
 <p>In many cases you will be able reply to the originator of the message by selecting the "Reply" button at the top of the message being displayed.</p>
 <p>The following is the message content</p>
-<p>  <%= @reply.body %></p>
+<%= simple_format(@reply.body) %>
 <p>The <%= @appname %> Team</p>

--- a/app/views/user_mailer/send_message.html.erb
+++ b/app/views/user_mailer/send_message.html.erb
@@ -7,5 +7,5 @@ Dear Colleague:
 <p>On the initial landing page after the log in; select the "Messages" button and on the list of messages select the "Show" for specific message identification <%=@message.identifier%>.</p>
 <p>In many cases you will be able reply to the originator of the message by selecting the "Reply" button at the top of the message being displayed.</p>
 <p>The following is the message content:</p>
-<p>  <%= @message.body %></p>
+<%= simple_format(@message.body) %>
 <p>The <%= @appname %> Team.</p>

--- a/app/views/userid_details/send_message.html.erb
+++ b/app/views/userid_details/send_message.html.erb
@@ -35,9 +35,9 @@
     <li class="grid__item  one-half  palm-one-whole push--bottom">
       <label>Comment or question<a href="#" class="right_tooltip"><%= image_tag 'png/info.png', alt: 'Information', height: '16' %> <span>If you want more information on volunteering to transcribe please indicate the county that is of most interest. If wanting to assist in the project management or development please indicate your area of expertise. </span></a></label>
       <% if @contact.body.nil? %>
-        <textarea name="contact[body]"  style="width: 100%;"  rows="8" ></textarea>
+        <textarea name="contact[body]"  style="width: 100%;" wrap="hard" cols="80"  rows="8" ></textarea>
       <% else%>
-        <textarea name="contact[body]"  style="width: 100%;"  rows="8" ><%=@contact.body%></textarea>
+        <textarea name="contact[body]"  style="width: 100%;" wrap="hard" cols="80"  rows="8" ><%=@contact.body%></textarea>
       <% end%>
     </li>
     <li  class="grid__item  one-third  palm-one-whole push--bottom" id="contact_type_input">


### PR DESCRIPTION
Textarea submissions were displayed with no line-break handling in most mailer templates and several admin views, so multi-line text collapsed into a single run-together paragraph. The two spots that attempted a fix relied on CSS white-space: pre-wrap, which many email clients (e.g. Gmail) strip, silently undoing it.

Switch all of these to Rails' simple_format, which converts blank lines to paragraph breaks and single newlines to <br>, both of which render correctly in browsers and email clients alike. Also add wrap="hard" to the remaining input textareas so they're consistent with the Contact us form.