### PR TITLE
Documentation for local setup of MyopicVicar #2991

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ package-lock.json
 .env.*.local
 
 data/*
+dev/docker/seed-data/
 
 .robocop.yml
 

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -1,0 +1,37 @@
+FROM ruby:2.7-bullseye
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    default-libmysqlclient-dev \
+    git \
+    graphviz \
+    imagemagick \
+    less \
+    liblzma-dev \
+    libxml2 \
+    libxml2-dev \
+    libxslt-dev \
+    mariadb-client \
+    nodejs \
+    npm \
+    pkg-config \
+    shared-mime-info \
+    zlib1g-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN gem install bundler -v 2.2.16
+
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle config set --global without production \
+  && bundle install --jobs=8 --retry=3
+
+ENV PATH="/app/dev/docker/bin:/app/bin:${PATH}"
+EXPOSE 3000
+
+CMD ["sleep", "infinity"]

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN gem install bundler -v 2.2.16
+RUN gem install bundler -v 2.4.22
 
 WORKDIR /app
 

--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -1,0 +1,146 @@
+# MyopicVicar Local Docker Environment
+
+A quick guide to get [MyopicVicar](https://github.com/FreeUKGen/MyopicVicar) up and running locally.
+
+## Prerequisites
+
+- macOS (tested) or Linux (untested)
+- Docker with Docker Compose v2
+- A local MyopicVicar fork:
+  - Fork [MyopicVicar](https://github.com/FreeUKGen/MyopicVicar)
+  - Clone fork locally
+
+This setup is for local development only. Do not add production credentials,
+private data, or production configuration to this directory.
+
+## Download Seed Data
+
+Download `seed-data.zip` from the
+[MyopicVicar development-data release](https://github.com/sagar-ruby/MyopicVicar-development-data/releases/tag/v1.0.0).
+
+Unzip the archive into `dev/docker` so these directories exist:
+
+```text
+dev/docker/seed-data/mongo_import/
+dev/docker/seed-data/users/testuser4/
+```
+
+The whole `seed-data` directory is ignored by Git but must be present before the
+first installation.
+
+## First Install
+
+From the repository root, run:
+
+```bash
+# Build and start the app, MariaDB, and MongoDB containers
+docker compose -f dev/docker/compose.yaml up -d --build
+```
+
+```bash
+# Import reference data such as counties, places, churches, and registers
+docker compose -f dev/docker/compose.yaml exec -e LOAD_DATA=mongo app mv-setup
+```
+
+```bash
+# Import sample records and build search indexes and the place cache
+docker compose -f dev/docker/compose.yaml exec -e LOAD_DATA=data app mv-setup
+```
+
+```bash
+# Generate the application's public images, stylesheets, and JavaScript
+docker compose -f dev/docker/compose.yaml exec app mv-assets
+```
+
+```bash
+# Start Rails in the background
+docker compose -f dev/docker/compose.yaml exec -d app mv-server
+```
+
+The `mongo` step imports reference collections such as counties and places. The
+`data` step imports the sample records and builds the search indexes and place
+dropdown cache. Run them in that order on a fresh database; the data step can
+take several minutes.
+
+## Services
+
+Check the containers with:
+
+```bash
+docker compose -f dev/docker/compose.yaml ps
+```
+
+| Service | Host address |
+|---------|--------------|
+| Rails | <http://127.0.0.1:3001> |
+| MariaDB 10.3 | `127.0.0.1:3307` |
+| MongoDB 4.4 | `127.0.0.1:27018` |
+
+Database and gem data are stored in named Docker volumes and survive a normal
+container restart.
+
+## First Manual Test
+
+Open <http://localhost:3001> then use the search to confirm that this search returns Mary Fowler's burial at Acle on 7 August 1805:
+
+```text
+Surname: Fowler
+Forename(s): Mary
+First year: 1805
+Last year: 1805
+Record Type: Burial
+County: Norfolk
+Place: Acle
+```
+
+## Daily Use
+
+Start the containers and Rails:
+
+```bash
+docker compose -f dev/docker/compose.yaml up -d
+docker compose -f dev/docker/compose.yaml exec -d app mv-server
+```
+
+Stop the containers:
+
+```bash
+docker compose -f dev/docker/compose.yaml down
+```
+
+## Useful Commands
+
+```bash
+# Follow Rails logs
+docker compose -f dev/docker/compose.yaml logs -f app
+
+# Open a Rails console
+docker compose -f dev/docker/compose.yaml exec app mv-console
+
+# Run RSpec
+docker compose -f dev/docker/compose.yaml exec app mv-rspec
+
+# Open a shell in the app container
+docker compose -f dev/docker/compose.yaml exec app bash
+```
+
+## Troubleshooting
+
+### Missing places or search results
+
+Both seed commands must finish successfully. The place dropdown uses a cache
+built by `LOAD_DATA=data`; importing only the Mongo reference collections is not
+enough.
+
+### Missing images, styling, or JavaScript
+
+Regenerate the public assets:
+
+```bash
+docker compose -f dev/docker/compose.yaml exec app mv-assets
+```
+
+### Rails reports an existing server
+
+Run `mv-server` again. It removes a stale `tmp/pids/server.pid` when no matching
+server process is running.

--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -1,17 +1,25 @@
 # MyopicVicar Local Docker Environment
 
-A quick guide to get [MyopicVicar](https://github.com/FreeUKGen/MyopicVicar) up and running locally.
+- A quick guide to get [MyopicVicar](https://github.com/FreeUKGen/MyopicVicar) up and running locally.
+- Time Required: ~1 hour
 
-## Prerequisites
+This guide is for local development only. Do not add production credentials, private data, or production configuration to the `dev` directory.
 
-- macOS (tested) or Linux (untested)
-- Docker with Docker Compose v2
-- A local MyopicVicar fork:
+## Tested on:
+
+Use either of the following OS setups:
+
+- macOS, Docker with Docker Compose v2
+- Windows 11, Docker Desktop, WSL2
+
+However due to containerisation, this guide will likely also work with native Linux + Docker.
+
+## Repository
+
+You will need a local MyopicVicar fork, do the following:
+  
   - Fork [MyopicVicar](https://github.com/FreeUKGen/MyopicVicar)
   - Clone fork locally
-
-This setup is for local development only. Do not add production credentials,
-private data, or production configuration to this directory.
 
 ## Download Seed Data
 

--- a/dev/docker/bin/mv-assets
+++ b/dev/docker/bin/mv-assets
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+exec bash dev/docker/compose_public_assets.sh "$@"

--- a/dev/docker/bin/mv-console
+++ b/dev/docker/bin/mv-console
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+exec bundle exec rails console "$@"

--- a/dev/docker/bin/mv-rspec
+++ b/dev/docker/bin/mv-rspec
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+exec bundle exec rspec "$@"

--- a/dev/docker/bin/mv-server
+++ b/dev/docker/bin/mv-server
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+
+pid_file="tmp/pids/server.pid"
+if [ -f "$pid_file" ]; then
+  server_pid="$(cat "$pid_file")"
+  if ! kill -0 "$server_pid" 2>/dev/null; then
+    echo "Removing stale Rails server PID file: $pid_file"
+    rm -f "$pid_file"
+  fi
+fi
+
+exec rails server -b 0.0.0.0 "$@"

--- a/dev/docker/bin/mv-setup
+++ b/dev/docker/bin/mv-setup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+exec bash dev/docker/compose_setup.sh "$@"

--- a/dev/docker/compose-config/database.yml
+++ b/dev/docker/compose-config/database.yml
@@ -1,0 +1,19 @@
+development:
+  adapter: mysql2
+  encoding: utf8
+  database: freereg2_development
+  pool: 5
+  username: freereg2
+  password: freereg2
+  host: mysql
+  port: 3306
+
+test:
+  adapter: mysql2
+  encoding: utf8
+  database: freereg2_development
+  pool: 5
+  username: freereg2
+  password: freereg2
+  host: mysql
+  port: 3306

--- a/dev/docker/compose-config/errbit.yml
+++ b/dev/docker/compose-config/errbit.yml
@@ -1,0 +1,10 @@
+development:
+  api_key: "local-development-placeholder"
+  project_id: 1
+  host: ""
+  secure: false
+
+test:
+  api_key: "1"
+  project_id: 1
+  host: ""

--- a/dev/docker/compose-config/freeukgen_application.yml
+++ b/dev/docker/compose-config/freeukgen_application.yml
@@ -1,0 +1,17 @@
+development:
+  template_set: 'freereg'
+  gtm_key: ''
+  advert_key:
+    data_ad_client: ""
+    data_ad_slot_header: ""
+    data_ad_slot_google_advert: ""
+    data_ad_slot_coverage: ""
+    data_ad_slot_fullwidth: ""
+    data_ad_slot_side: ""
+
+test:
+  template_set: 'freereg'
+  gtm_key: ''
+  advert_key:
+    data_ad_client: ""
+    data_ad_slot_header: ""

--- a/dev/docker/compose-config/mongo_config.yml
+++ b/dev/docker/compose-config/mongo_config.yml
@@ -1,0 +1,26 @@
+development:
+  sleep: '0.0'
+  emmendation_sleep: '0'
+  mongodb_bin_location: '/usr/bin'
+  datafiles: 'tmp/users/'
+  datafiles_changeset: ''
+  website: 'localhost:3001'
+  delete_list: 'log/delete_files'
+  fc_update_processor_status_file: ''
+  member_open: true
+  ucf_support: true
+  wildcard_support: true
+  witness_support: true
+  github_issues_login: ''
+  github_issues_password: ''
+  github_issues_repo: ''
+  days_to_retain_search_queries: 10
+  max_search_time: 50000
+  our_secret_key: 'I do not think that word means what you think it means.'
+  secret_key_base:
+  timeout_researcher: 120
+  timeout_transcriber: 60
+  timeout_manager: 240
+  register_embargo_list: 'log/register_embargo_list'
+
+test:

--- a/dev/docker/compose-config/mongoid.yml
+++ b/dev/docker/compose-config/mongoid.yml
@@ -1,0 +1,28 @@
+development:
+  clients:
+    default:
+      database: myopic_vicar_development
+      hosts:
+        - mongo:27017
+      options:
+    local_writable:
+      database: writable_development
+      hosts:
+        - mongo:27017
+      options:
+  options:
+    raise_not_found_error: false
+    scope_overwrite_exception: false
+
+test:
+  clients:
+    default:
+      database: freereg_development
+      hosts:
+        - mongo:27017
+      options:
+    local_writable:
+      database: writable_development
+      hosts:
+        - mongo:27017
+      options:

--- a/dev/docker/compose-config/secrets.yml
+++ b/dev/docker/compose-config/secrets.yml
@@ -1,0 +1,7 @@
+development:
+  secret_token: 'local-development-secret-token-placeholder-not-for-production'
+  secret_key_base: 'local-development-secret-key-base-placeholder-not-for-production'
+
+test:
+  secret_token: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+  secret_key_base: 'test-secret-key-base-for-compose-development-only'

--- a/dev/docker/compose.yaml
+++ b/dev/docker/compose.yaml
@@ -1,0 +1,59 @@
+name: myopicvicar
+
+x-app-env: &app-env
+  RAILS_ENV: development
+  LOAD_DATA: ${LOAD_DATA:-none}
+  MONGO_HOST: mongo
+  MONGO_PORT: "27017"
+  MYOPIC_VICAR_IMPORT_DIR: ./tmp/mongo_import
+  NEW_RELIC_AGENT_ENABLED: "false"
+
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: dev/docker/Dockerfile
+    image: myopicvicar_app:compose
+    working_dir: /app
+    volumes:
+      - ../../:/app:cached
+      - bundle_data:/usr/local/bundle
+    environment:
+      <<: *app-env
+    ports:
+      - "127.0.0.1:3001:3000"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      mongo:
+        condition: service_started
+
+  mysql:
+    image: mariadb:10.3
+    environment:
+      MYSQL_ROOT_PASSWORD: rootroot
+      MYSQL_DATABASE: freereg2_development
+      MYSQL_USER: freereg2
+      MYSQL_PASSWORD: freereg2
+    ports:
+      - "127.0.0.1:3307:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-prootroot"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  mongo:
+    image: mongo:4.4
+    command: ["mongod", "--bind_ip_all"]
+    ports:
+      - "127.0.0.1:27018:27017"
+    volumes:
+      - mongo_data:/data/db
+
+volumes:
+  bundle_data:
+  mysql_data:
+  mongo_data:

--- a/dev/docker/compose_mongo_import.rb
+++ b/dev/docker/compose_mongo_import.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require 'json'

--- a/dev/docker/compose_mongo_import.rb
+++ b/dev/docker/compose_mongo_import.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'mongo'
+require 'time'
+
+database = ARGV.fetch(0)
+collection_name = ARGV.fetch(1)
+file_path = ARGV.fetch(2)
+host = ENV.fetch('MONGO_HOST', 'mongo')
+port = ENV.fetch('MONGO_PORT', '27017')
+
+def convert_extended_json(value)
+  case value
+  when Array
+    value.map { |item| convert_extended_json(item) }
+  when Hash
+    return BSON::ObjectId.from_string(value['$oid']) if value.keys == ['$oid']
+    return Time.parse(value['$date']).utc if value.keys == ['$date']
+
+    value.transform_values { |item| convert_extended_json(item) }
+  else
+    value
+  end
+end
+
+client = Mongo::Client.new(["#{host}:#{port}"], database: database)
+collection = client[collection_name]
+
+count = 0
+File.foreach(file_path) do |line|
+  next if line.strip.empty?
+
+  collection.insert_one(convert_extended_json(JSON.parse(line)))
+  count += 1
+end
+
+puts "Imported #{count} documents into #{database}.#{collection_name}"

--- a/dev/docker/compose_public_assets.sh
+++ b/dev/docker/compose_public_assets.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+
+rm -rf public/images public/stylesheets public/javascripts
+mkdir -p public/images
+mkdir -p public/stylesheets
+mkdir -p public/javascripts
+
+bundle exec rails runner - <<'RUBY'
+require 'fileutils'
+
+environment = Rails.application.assets || Sprockets::Railtie.build_environment(Rails.application)
+
+assets = {
+  'application.css' => 'application.css',
+  'styles/css/donate_icon.css' => 'styles/css/donate_icon.css',
+  'styles/css/icons.data.svg.css' => 'styles/css/icons.data.svg.css',
+  'styles/css/freereg_content.css' => 'styles/css/freereg_content.css',
+  'styles/scss/palm.css' => 'styles/scss/palm.css',
+  'styles/scss/lap_and_up.css' => 'styles/scss/lap_and_up.css',
+  'styles/scss/ladda.css' => 'styles/scss/ladda.css'
+}
+
+assets.each do |logical_path, output_path|
+  asset = environment.find_asset(logical_path)
+  raise "Missing asset #{logical_path}" unless asset
+
+  destination = Rails.root.join('public', 'stylesheets', output_path)
+  FileUtils.mkdir_p(File.dirname(destination))
+  File.binwrite(destination, asset.to_s)
+  puts "wrote #{destination.relative_path_from(Rails.root)}"
+end
+
+scripts = {
+  'application.js' => 'application.js',
+  'jquery.min.js' => 'jquery.min.js',
+  'jquery.chained.remote.js' => 'jquery.chained.remote.js',
+  'cookie_control.js' => 'cookie_control.js',
+  'jquery.cookiesDirective.js' => 'jquery.cookiesDirective.js',
+  'spin.min.js' => 'spin.min.js',
+  'ladda.min.js' => 'ladda.min.js',
+  'freecen_coverage_graph.js' => 'freecen_coverage_graph.js',
+  'javascripts/freereg_fuse_tag.js' => 'javascripts/freereg_fuse_tag.js'
+}
+
+scripts.each do |logical_path, output_path|
+  asset = environment.find_asset(logical_path)
+  raise "Missing asset #{logical_path}" unless asset
+
+  destination = Rails.root.join('public', 'javascripts', output_path)
+  FileUtils.mkdir_p(File.dirname(destination))
+  File.binwrite(destination, asset.to_s)
+  puts "wrote #{destination.relative_path_from(Rails.root)}"
+end
+RUBY
+
+cp -R app/assets/images/. public/images/
+echo "copied public/images"

--- a/dev/docker/compose_setup.sh
+++ b/dev/docker/compose_setup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  echo "[compose_setup]" "$@"
+}
+
+mkdir -p public/system tmp/users/testuser4 tmp/mongo_import
+
+copy_seed_files() {
+  local source_dir="$1"
+  local target_dir="$2"
+
+  if [ -d "$source_dir" ] && ! find "$target_dir" -mindepth 1 -print -quit | grep -q .; then
+    log "Installing seed files into $target_dir"
+    cp "$source_dir"/* "$target_dir"/
+  fi
+}
+
+copy_seed_files dev/docker/seed-data/mongo_import tmp/mongo_import
+copy_seed_files dev/docker/seed-data/users/testuser4 tmp/users/testuser4
+
+copy_config() {
+  local source_file="$1"
+  local target_file="$2"
+
+  if [ ! -f "$target_file" ] || [ "${FORCE_CONFIG:-false}" = "true" ]; then
+    log "Installing $target_file"
+    cp "$source_file" "$target_file"
+  fi
+}
+
+copy_config dev/docker/compose-config/database.yml config/database.yml
+copy_config dev/docker/compose-config/mongoid.yml config/mongoid.yml
+copy_config dev/docker/compose-config/mongo_config.yml config/mongo_config.yml
+copy_config dev/docker/compose-config/errbit.yml config/errbit.yml
+copy_config dev/docker/compose-config/freeukgen_application.yml config/freeukgen_application.yml
+copy_config dev/docker/compose-config/secrets.yml config/secrets.yml
+
+log "Waiting for MariaDB"
+until mysqladmin ping -h mysql -ufreereg2 -pfreereg2 --silent; do
+  sleep 2
+done
+
+log "Waiting for MongoDB"
+until timeout 2 bash -c "cat < /dev/null > /dev/tcp/${MONGO_HOST:-mongo}/${MONGO_PORT:-27017}"; do
+  sleep 2
+done
+
+log "Installing gems"
+bundle check || bundle install --jobs=8 --retry=3
+
+log "Running FreeREG setup script with LOAD_DATA=${LOAD_DATA:-none}"
+bash dev/docker/fugsetup_all.sh

--- a/dev/docker/fugsetup_all.sh
+++ b/dev/docker/fugsetup_all.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  echo "[fugsetup]" "$@"
+}
+
+load_data="${LOAD_DATA:-none}"
+mongo_host="${MONGO_HOST:-mongo}"
+mongo_port="${MONGO_PORT:-27017}"
+import_dir="${MYOPIC_VICAR_IMPORT_DIR:-./tmp/mongo_import}"
+
+mongo_import() {
+  local collection="$1"
+  local file="${import_dir}/${collection}.json"
+
+  if [ ! -f "$file" ]; then
+    log "Missing Mongo seed file: $file"
+    exit 1
+  fi
+
+  log "Importing Mongo collection: $collection"
+  if command -v mongoimport >/dev/null 2>&1; then
+    mongoimport \
+      --host "$mongo_host" \
+      --port "$mongo_port" \
+      --db myopic_vicar_development \
+      --collection "$collection" \
+      --file "$file"
+  else
+    ruby dev/docker/compose_mongo_import.rb \
+      myopic_vicar_development \
+      "$collection" \
+      "$file"
+  fi
+}
+
+load_mongo_seed_data() {
+  local collections=(
+    places
+    churches
+    counties
+    countries
+    denominations
+    registers
+    syndicates
+    userid_details
+    emendation_rules
+    emendation_types
+  )
+
+  local collection
+  for collection in "${collections[@]}"; do
+    mongo_import "$collection"
+  done
+
+  log "Mongo reference data import complete"
+}
+
+load_application_seed_data() {
+  log "Building FreeREG records from the runtime CSV files"
+  bundle exec rake build:freereg_from_files[,,,,1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19,27017] --trace
+
+  log "Connecting UserID details to Refinery users"
+  bundle exec rake freeuk:add_user --trace
+
+  log "Loading emendations"
+  bundle exec rake load_emendations --trace
+
+  log "Creating FreeREG entries and search records"
+  bundle exec rake build:recommence_freereg_new_update[create_search_records,range,force_rebuild,a-9] --trace
+
+  log "Creating FreeREG search indexes"
+  bundle exec rails runner 'SearchRecord::REG_PLACE_INDEXES.merge(SearchRecord::REG_CHAPMAN_INDEXES).merge(SearchRecord::REG_BASIC_INDEXES).each { |name, fields| SearchRecord.collection.indexes.create_one(fields.map { |field| [field, 1] }.to_h, name: name, background: true) }'
+
+  log "Refreshing the places cache"
+  bundle exec rake foo:refresh_places_cache
+
+  log "Calculating transcription content"
+  bundle exec rake freereg:calculate_freereg_content --trace
+
+  log "Application seed data import complete"
+}
+
+log "LOAD_DATA=$load_data"
+
+case "$load_data" in
+  none)
+    log "No seed data requested"
+    ;;
+  mongo)
+    load_mongo_seed_data
+    ;;
+  data)
+    load_application_seed_data
+    ;;
+  *)
+    log "Unsupported LOAD_DATA value: $load_data"
+    log "Supported values: none, mongo, data"
+    exit 64
+    ;;
+esac


### PR DESCRIPTION
### Summary
Guide for local docker compose setup #2991.

A new directory `./dev` has been added with relevant files and a `README.md`. This is isolated so nothing in production will be affected. Only the .gitignore file has been amended from the current codebase.

### More details

- Adds a shared Docker Compose environment for local MyopicVicar development.

- Runs Rails, MariaDB 10.3, and MongoDB 4.4 in separate containers.

- Adds helper commands for setup, assets, Rails server, console, and RSpec.

- Supports importing reference Mongo collections and sample searchable data.

- Automatically builds search indexes and the county/place dropdown cache.

- Adds sanitised development and test configuration templates.

- Excludes production configuration, credentials, and deployment changes.

- Keeps seed data outside the main repository and downloads it separately from a GitHub release.

- Adds a concise setup README with installation, verification, daily-use, and troubleshooting instructions.

- Verified through a clean installation from empty Docker containers and volumes.
