### PR TITLE
2969: Fix The action 'new' could not be found for SearchRecordsController

### DIFF
--- a/app/controllers/search_records_controller.rb
+++ b/app/controllers/search_records_controller.rb
@@ -44,6 +44,11 @@ class SearchRecordsController < ApplicationController
     redirect_back_or_new_search_query && return
   end
 
+  def new
+    flash[:notice] = 'That action does not exist'
+    redirect_back_or_new_search_query && return
+  end
+
   def show
     session[:query] = params[:search_id] if params[:search_id].present?
     proceed, @search_query, @search_record, message = SearchRecord.check_show_parameters(session[:query], params)
@@ -374,7 +379,7 @@ class SearchRecordsController < ApplicationController
   def viewed
     session[:viewed] ||= []
   end
-  
+
   private
 
   # Citation links are often opened from other sites; redirect_back would send users to the Referer (that site)

--- a/app/controllers/search_records_controller.rb
+++ b/app/controllers/search_records_controller.rb
@@ -44,11 +44,6 @@ class SearchRecordsController < ApplicationController
     redirect_back_or_new_search_query && return
   end
 
-  def new
-    flash[:notice] = 'That action does not exist'
-    redirect_back_or_new_search_query && return
-  end
-
   def show
     session[:query] = params[:search_id] if params[:search_id].present?
     proceed, @search_query, @search_record, message = SearchRecord.check_show_parameters(session[:query], params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -603,7 +603,7 @@ MyopicVicar::Application.routes.draw do
   get 'search_records/:id/show_print_version(.:format)', :to => 'search_records#show_print_version', :as => :show_print_version_search_record
   get 'search_records/:id/show_citation', :to => 'search_records#show_citation', :as => :show_citation_record
   get 'search_records/:id/:friendly(.:format)', :to => 'search_records#show', :as => :friendly_search_record
-  resources :search_records
+  resources :search_records, only: [:show], constraints: { id: /[0-9a-f]{24}/ }
 
   get 'search_queries/:id/show_query', :to => 'search_queries#show_query', :as => :show_query_search_query
   get 'search_queries/:id/show_print_version', :to => 'search_queries#show_print_version', :as => :show_print_version_search_query

--- a/spec/controllers/search_records_controller_spec.rb
+++ b/spec/controllers/search_records_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe SearchRecordsController do
+  describe 'routing', type: :routing do
+    let(:object_id) { '507f1f77bcf86cd799439011' }
+
+    it 'routes GET /search_records/:id (a Mongo ObjectId) to #show' do
+      expect(get: "/search_records/#{object_id}").to route_to('search_records#show', id: object_id)
+    end
+
+    it 'no longer routes GET /search_records to #index' do
+      expect(get: '/search_records').not_to route_to('search_records#index')
+    end
+
+    it 'does not route POST /search_records (create)' do
+      expect(post: '/search_records').not_to be_routable
+    end
+
+    it 'does not route PATCH /search_records/:id (update)' do
+      expect(patch: "/search_records/#{object_id}").not_to be_routable
+    end
+
+    it 'does not route DELETE /search_records/:id (destroy)' do
+      expect(delete: "/search_records/#{object_id}").not_to be_routable
+    end
+  end
+
+  describe 'GET /search_records/new', type: :request do
+    # :id on the show route is now constrained to a Mongo ObjectId shape, so
+    # "new" never matches it and falls through to the site's catch-all page
+    # route (pages#show) instead, which renders a plain 404.
+    it 'returns 404 without ever instantiating SearchRecordsController' do
+      expect(SearchRecordsController).not_to receive(:new)
+
+      get '/search_records/new'
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
added redirect to search_records#new