### PR TITLE
Fix missing church handling in unique church names

### DIFF
--- a/app/controllers/freereg_contents_controller.rb
+++ b/app/controllers/freereg_contents_controller.rb
@@ -207,6 +207,7 @@ class FreeregContentsController < ApplicationController
   end
 
   def unique_church_names
+    # This derived summary can outlive its Church, so check that both still exist.
     @church = ChurchUniqueName.find_by(church_id: params[:id])
     actual_church = Church.find_by(_id: params[:id])
     redirect_back(fallback_location: { action: 'new' }, notice: 'That place does not exist') && return if @church.blank? || actual_church.blank?

--- a/app/controllers/freereg_contents_controller.rb
+++ b/app/controllers/freereg_contents_controller.rb
@@ -208,7 +208,8 @@ class FreeregContentsController < ApplicationController
 
   def unique_church_names
     @church = ChurchUniqueName.find_by(church_id: params[:id])
-    redirect_back(fallback_location: { action: 'new' }, notice: 'That place does not exist') && return if @church.blank?
+    actual_church = Church.find_by(_id: params[:id])
+    redirect_back(fallback_location: { action: 'new' }, notice: 'That place does not exist') && return if @church.blank? || actual_church.blank?
 
     @unique_forenames = @church.unique_forenames
     @unique_surnames = @church.unique_surnames

--- a/spec/controllers/freereg_contents_controller_spec.rb
+++ b/spec/controllers/freereg_contents_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe FreeregContentsController, type: :controller do
+  describe 'GET unique_church_names' do
+    let(:church_id) { 'church-id' }
+
+    before do
+      allow(controller).to receive(:load_last_stat)
+    end
+
+    it 'redirects when the ChurchUniqueName has no corresponding Church' do
+      summary = double('church unique name', unique_forenames: [], unique_surnames: [])
+      allow(ChurchUniqueName).to receive(:find_by).with(church_id: church_id).and_return(summary)
+      allow(Church).to receive(:find_by).with(_id: church_id).and_return(nil)
+
+      get :unique_church_names, params: { id: church_id }
+
+      expect(response).to redirect_to(new_freereg_content_path)
+      expect(flash[:notice]).to eq('That place does not exist')
+    end
+
+    it 'redirects when the ID does not identify a ChurchUniqueName or Church' do
+      allow(ChurchUniqueName).to receive(:find_by).with(church_id: church_id).and_return(nil)
+      allow(Church).to receive(:find_by).with(_id: church_id).and_return(nil)
+
+      get :unique_church_names, params: { id: church_id }
+
+      expect(response).to redirect_to(new_freereg_content_path)
+      expect(flash[:notice]).to eq('That place does not exist')
+    end
+
+    it 'continues normally when both the ChurchUniqueName and Church exist' do
+      summary = double('church unique name', unique_forenames: ['Jane'], unique_surnames: ['Doe'])
+      church = double('church')
+      allow(ChurchUniqueName).to receive(:find_by).with(church_id: church_id).and_return(summary)
+      allow(Church).to receive(:find_by).with(_id: church_id).and_return(church)
+      expect(controller).to receive(:variables_for_church_show)
+
+      get :unique_church_names, params: { id: church_id }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
Closes #2970.\n\nStale `ChurchUniqueName` records can outlive their underlying `Church`. The `unique_church_names` action previously passed such IDs to `variables_for_church_show`, which dereferenced the missing church and raised `undefined method 'place' for nil:NilClass`.\n\nThe endpoint now verifies that the underlying church exists and uses the existing redirect and notice when either record is missing. Regression coverage includes orphaned summaries, unknown IDs, and valid records.