### PR TITLE
Sortable tables

### DIFF
--- a/app/assets/javascripts/sortable_table.js
+++ b/app/assets/javascripts/sortable_table.js
@@ -1,0 +1,155 @@
+(function(root, factory) {
+  var SortableTable = factory();
+
+  if (typeof module === 'object' && module.exports) {
+    module.exports = SortableTable;
+  }
+
+  if (root) {
+    root.SortableTable = SortableTable;
+  }
+})(typeof window !== 'undefined' ? window : null, function() {
+  'use strict';
+
+  var MONTHS = {
+    jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,
+    jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11
+  };
+
+  function textValue(cell) {
+    var explicitValue = cell.getAttribute('data-sort-value');
+    return (explicitValue === null ? cell.textContent : explicitValue).trim();
+  }
+
+  function numberValue(value) {
+    var number = Number(value.replace(/,/g, ''));
+    return Number.isNaN(number) ? null : number;
+  }
+
+  function dateValue(value) {
+    var isoDate = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (isoDate) {
+      return Date.UTC(Number(isoDate[1]), Number(isoDate[2]) - 1, Number(isoDate[3]));
+    }
+
+    var displayedDate = /^(\d{1,2})\s+([A-Za-z]{3})\s+(\d{4})$/.exec(value);
+    if (displayedDate) {
+      var month = MONTHS[displayedDate[2].toLowerCase()];
+      if (month !== undefined) {
+        return Date.UTC(Number(displayedDate[3]), month, Number(displayedDate[1]));
+      }
+    }
+
+    return null;
+  }
+
+  function typedValue(value, type) {
+    if (value === '') return null;
+    if (type === 'number') return numberValue(value);
+    if (type === 'date') return dateValue(value);
+    return value.toLocaleLowerCase();
+  }
+
+  function compareValues(left, right, type) {
+    var leftValue = typedValue(left, type);
+    var rightValue = typedValue(right, type);
+
+    if (leftValue === null && rightValue === null) return 0;
+    if (leftValue === null) return 1;
+    if (rightValue === null) return -1;
+    if (leftValue < rightValue) return -1;
+    if (leftValue > rightValue) return 1;
+    return 0;
+  }
+
+  function SortableTable(table) {
+    this.table = table;
+    this.headings = Array.prototype.slice.call(
+      table.querySelectorAll('thead th[data-sort-type]')
+    );
+    this.bindHeadings();
+  }
+
+  SortableTable.prototype.bindHeadings = function() {
+    var sortableTable = this;
+
+    this.headings.forEach(function(heading) {
+      heading.setAttribute('aria-sort', 'none');
+      heading.setAttribute('tabindex', '0');
+      heading.setAttribute('title', 'Double-click or press Enter to sort');
+
+      var indicator = heading.ownerDocument.createElement('span');
+      indicator.className = 'sortable-table__indicator';
+      indicator.setAttribute('aria-hidden', 'true');
+      indicator.textContent = ' ⇅';
+      heading.appendChild(indicator);
+
+      heading.addEventListener('dblclick', function() {
+        sortableTable.sortBy(heading);
+      });
+      heading.addEventListener('keydown', function(event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          sortableTable.sortBy(heading);
+        }
+      });
+    });
+  };
+
+  SortableTable.prototype.sortBy = function(heading) {
+    var direction = heading.getAttribute('aria-sort') === 'ascending' ? 'descending' : 'ascending';
+    var columnIndex = heading.cellIndex;
+    var type = heading.getAttribute('data-sort-type');
+    var multiplier = direction === 'ascending' ? 1 : -1;
+
+    Array.prototype.slice.call(this.table.tBodies).forEach(function(body) {
+      var rows = Array.prototype.slice.call(body.rows).map(function(row, index) {
+        return { row: row, originalIndex: index };
+      });
+
+      rows.sort(function(left, right) {
+        var leftText = textValue(left.row.cells[columnIndex]);
+        var rightText = textValue(right.row.cells[columnIndex]);
+        var comparison = compareValues(leftText, rightText, type);
+
+        // Empty or invalid values stay at the end in either direction.
+        if (typedValue(leftText, type) === null || typedValue(rightText, type) === null) {
+          return comparison || left.originalIndex - right.originalIndex;
+        }
+
+        return (comparison * multiplier) || left.originalIndex - right.originalIndex;
+      });
+
+      rows.forEach(function(item) { body.appendChild(item.row); });
+    });
+
+    this.headings.forEach(function(item) {
+      var active = item === heading;
+      item.setAttribute('aria-sort', active ? direction : 'none');
+      item.querySelector('.sortable-table__indicator').textContent = active ?
+        (direction === 'ascending' ? ' \u25b2' : ' \u25bc') : ' ⇅';
+    });
+  };
+
+  SortableTable.compareValues = compareValues;
+  SortableTable.typedValue = typedValue;
+
+  SortableTable.initialize = function(documentRoot) {
+    Array.prototype.slice.call(documentRoot.querySelectorAll('table.js-sortable-table')).forEach(function(table) {
+      if (table.getAttribute('data-sortable-table-initialized') === 'true') return;
+      table.setAttribute('data-sortable-table-initialized', 'true');
+      new SortableTable(table);
+    });
+  };
+
+  return SortableTable;
+});
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', function() {
+    window.SortableTable.initialize(document);
+  });
+  document.addEventListener('turbolinks:load', function() {
+    window.SortableTable.initialize(document);
+  });
+}

--- a/app/views/freereg1_csv_files/index.html.erb
+++ b/app/views/freereg1_csv_files/index.html.erb
@@ -6,21 +6,21 @@
   <div class="grid__item ">
     <section class="island ">
       <div class="scrollable " >
-        <table class=' table--bordered my-width table--data table--striped just--left'>
+        <table class='table--bordered my-width table--data table--striped just--left js-sortable-table'>
           <thead >
             <tr>
-              <th class='sticky-header'>File</th>
-              <th class='sticky-header'>Cty</th>
-              <th class='sticky-header'>Place</th>
-              <th class='sticky-header'>Church</th>
-              <th class='sticky-header'>Reg</th>
-              <th class='sticky-header'>Entries</th>
-              <th class='sticky-header'>Start year</th>
-              <th class='sticky-header'>End year</th>
+              <th class='sticky-header' data-sort-type='text'>File</th>
+              <th class='sticky-header' data-sort-type='text'>Cty</th>
+              <th class='sticky-header' data-sort-type='text'>Place</th>
+              <th class='sticky-header' data-sort-type='text'>Church</th>
+              <th class='sticky-header' data-sort-type='text'>Reg</th>
+              <th class='sticky-header' data-sort-type='number'>Entries</th>
+              <th class='sticky-header' data-sort-type='number'>Start year</th>
+              <th class='sticky-header' data-sort-type='number'>End year</th>
               <% unless session[:my_own]%>
-                <th class='sticky-header'>User ID</th>
+                <th class='sticky-header' data-sort-type='text'>User ID</th>
               <% end%>
-              <th class='sticky-header' >Last Modified</th>
+              <th class='sticky-header' data-sort-type='date'>Last Modified</th>
               <th colspan = "2" class='sticky-header'>Locked<br>
                 TR SC</th>
               <th colspan="7" class='sticky-header'>Action <a href="#" class="left_tooltip" onclick="return false;"><%= image_tag 'png/info.png', alt: 'Information', height: '16' %><span>SH: Show header; ED: Edit header; DL: Download batch; ER: Errors in batch; L: Lock batch; U: Unlock batch; DE: Delete batch;RL:Replace batch </span></a></th>

--- a/test/javascript/sortable_table_test.js
+++ b/test/javascript/sortable_table_test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+var assert = require('assert');
+var SortableTable = require('../../app/assets/javascripts/sortable_table');
+
+function test(name, callback) {
+  try {
+    callback();
+    console.log('PASS ' + name);
+  } catch (error) {
+    console.error('FAIL ' + name);
+    throw error;
+  }
+}
+
+function element(attributes) {
+  return {
+    attributes: attributes || {},
+    children: [],
+    listeners: {},
+    getAttribute: function(name) {
+      return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null;
+    },
+    setAttribute: function(name, value) { this.attributes[name] = value; },
+    appendChild: function(child) { this.children.push(child); },
+    addEventListener: function(name, callback) { this.listeners[name] = callback; },
+    querySelector: function(selector) {
+      if (selector === '.sortable-table__indicator') return this.children[0];
+      return null;
+    }
+  };
+}
+
+function sortableFixture(values, type) {
+  var document = {
+    createElement: function() { return element(); }
+  };
+  var heading = element({ 'data-sort-type': type });
+  heading.cellIndex = 0;
+  heading.ownerDocument = document;
+
+  var rows = values.map(function(value, index) {
+    var cell = element();
+    cell.textContent = value;
+    return { id: index, cells: [cell] };
+  });
+  var body = {
+    rows: rows,
+    appendChild: function(row) {
+      this.rows.splice(this.rows.indexOf(row), 1);
+      this.rows.push(row);
+    }
+  };
+  var table = {
+    tBodies: [body],
+    querySelectorAll: function() { return [heading]; }
+  };
+
+  return { sorter: new SortableTable(table), heading: heading, body: body };
+}
+
+test('sorts text without regard to case', function() {
+  assert.strictEqual(SortableTable.compareValues('Acle', 'briston', 'text'), -1);
+  assert.strictEqual(SortableTable.compareValues('acle', 'Acle', 'text'), 0);
+});
+
+test('sorts formatted numbers numerically', function() {
+  assert.strictEqual(SortableTable.compareValues('2', '10', 'number'), -1);
+  assert.strictEqual(SortableTable.compareValues('1,200', '300', 'number'), 1);
+});
+
+test('sorts displayed dates chronologically', function() {
+  assert.strictEqual(SortableTable.compareValues('7 Aug 1805', '12 Jan 1810', 'date'), -1);
+  assert.strictEqual(SortableTable.compareValues('2025-02-01', '2024-12-31', 'date'), 1);
+});
+
+test('puts blank and invalid typed values after valid values', function() {
+  assert.strictEqual(SortableTable.compareValues('', 'Acle', 'text'), 1);
+  assert.strictEqual(SortableTable.compareValues('unknown', '10', 'number'), 1);
+  assert.strictEqual(SortableTable.compareValues('', '', 'date'), 0);
+});
+
+test('reorders rows ascending and then descending', function() {
+  var fixture = sortableFixture(['10', '', '2'], 'number');
+
+  fixture.heading.listeners.dblclick();
+  assert.deepStrictEqual(fixture.body.rows.map(function(row) { return row.id; }), [2, 0, 1]);
+  assert.strictEqual(fixture.heading.getAttribute('aria-sort'), 'ascending');
+
+  fixture.heading.listeners.dblclick();
+  assert.deepStrictEqual(fixture.body.rows.map(function(row) { return row.id; }), [0, 2, 1]);
+  assert.strictEqual(fixture.heading.getAttribute('aria-sort'), 'descending');
+});
+
+test('supports keyboard sorting and exposes an instruction', function() {
+  var fixture = sortableFixture(['Briston', 'acle'], 'text');
+  var prevented = false;
+
+  fixture.heading.listeners.keydown({
+    key: 'Enter',
+    preventDefault: function() { prevented = true; }
+  });
+
+  assert.strictEqual(prevented, true);
+  assert.deepStrictEqual(fixture.body.rows.map(function(row) { return row.id; }), [1, 0]);
+  assert.strictEqual(fixture.heading.getAttribute('tabindex'), '0');
+  assert.strictEqual(fixture.heading.getAttribute('title'), 'Double-click or press Enter to sort');
+});


### PR DESCRIPTION
  Refs #2820

  This PR adds reusable client-side column sorting and applies it initially to the FreeREG Batches table.

  ## Review instructions

  1. Log in as a transcriber.
  2. Open **Batches**, for example `/freereg1_csv_files/my_own`.
  3. Double-click a sortable column heading to sort it.
  4. Double-click it again to reverse the direction.

  Sorting can also be activated using the Enter or Space key. It applies to the rows on the current page.

  If this approach is accepted, I can apply the shared behaviour to other suitable tables in a follow-up PR.

  The Lock and Action columns are intentionally not sortable.

  ## Testing

  Run the JavaScript tests:

  ```bash
  node test/javascript/sortable_table_test.js
  ```
  
  ## Manual Testing

  Manually verify sorting using the File, Entries, Start year, End year, and Last Modified columns. Confirm that:

  - Text sorting is case-insensitive.
  - Entries and years sort numerically.
  - Last Modified sorts chronologically.
  - Repeating the action reverses the direction.
  - Lock and Action columns remain unsortable.
