### PR TITLE
Update freecen-newsletters.html.erb for Sep

### DIFF
--- a/app/views/pages/freecen/about/freecen-newsletters.html.erb
+++ b/app/views/pages/freecen/about/freecen-newsletters.html.erb
@@ -17,6 +17,7 @@
       <div class="islet islet--bordered">
         <h2 class="title-block" id="downloads">Downloads available</h2>
         <ol class="sub-nav">
+          <li><a href="/freecen/newsletters/newsletter-2026-09.pdf">Sep 2026 Newsletter (PDF, 905 kB)</a> </li>
           <li><a href="/freecen/newsletters/newsletter-2026-08.pdf">Aug 2026 Newsletter (PDF, 241 kB)</a> </li>
           <li><a href="/freecen/newsletters/newsletter-2026-07.pdf">Jul 2026 Newsletter (PDF, 5.5 MB)</a> </li>
           <li><a href="/freecen/newsletters/newsletter-2026-06.pdf">Jun 2026 Newsletter (PDF, 265 kB)</a> </li>
@@ -28,7 +29,6 @@
           <li><a href="/freecen/newsletters/newsletter_2025_12.pdf">Dec 2025 Newsletter (PDF, 1 MB)</a> </li>
           <li><a href="/freecen/newsletters/newsletter_2025_11.pdf">Nov 2025 Newsletter (PDF, 586 kB)</a> </li>
           <li><a href="/freecen/newsletters/newsletter_2025_10.pdf">Oct 2025 Newsletter (PDF, 952 kB)</a> </li>
-          <li><a href="/freecen/newsletters/newsletter_2025_09.pdf">Sep 2025 Newsletter (PDF, 2 MB)</a> </li>
         </ol>
       </div>
     </nav>


### PR DESCRIPTION
This is the updated Newsletters page for Sep 2026 and should be deployed with the uploaded files for Aug and Sep.

Aug is included because it was missed last month, leaving the page with a broken link :-(